### PR TITLE
ui: unify the bottom map dock (status, timeline, stat tiles, attribution)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { BottomBar } from "./components/layout/BottomBar";
-import type { MapApi, MapLayers } from "./components/layout/Map3DCanvas";
+import type { MapApi, MapInfo, MapLayers } from "./components/layout/Map3DCanvas";
 import { MapViewport } from "./components/layout/MapViewport";
+import { ExaggerationControl } from "./components/layout/ExaggerationControl";
+import { SourceStatusBar } from "./components/layout/SourceStatusBar";
 import { RightPanel } from "./components/layout/RightPanel";
 import { Sidebar } from "./components/layout/Sidebar";
 import { TopBar, type SearchPlace } from "./components/layout/TopBar";
@@ -35,9 +37,10 @@ const GUTTER = 12;
 const TOPBAR_H = 60;
 const LEFT_W = 272;
 const RIGHT_W = 352;
-const BOTTOM_H = 96;
-/** Extra vertical room the timeline takes above the bottom row. */
-const TIMELINE_H = 76;
+/** Initial guess for the bottom dock height; the dock reports its real size once mounted. */
+const BOTTOM_DOCK_H = 276;
+/** Compact mode: status row + timeline stacked above the sheet. */
+const COMPACT_DOCK_H = 120;
 
 const DEFAULT_LAYERS: MapLayers = {
   imagery: true,
@@ -68,6 +71,8 @@ export default function App() {
   const [atIso, setAtIso] = useState<string | null>(INITIAL.atIso);
   const [exaggeration, setExaggeration] = useState(INITIAL.exaggeration ?? 1);
   const [pose, setPose] = useState<CameraPose | null>(INITIAL.pose);
+  const [mapInfo, setMapInfo] = useState<MapInfo | null>(null);
+  const [dockHeight, setDockHeight] = useState(BOTTOM_DOCK_H);
   const [quality, setQuality] = useState<QualityMode>("auto");
   const [qualityLevel, setQualityLevel] = useState<QualityLevel>("high");
   const handleQualityLevel = useCallback((level: QualityLevel) => setQualityLevel(level), []);
@@ -180,15 +185,15 @@ export default function App() {
             left: 8,
             right: 8,
             top: dockTop,
-            bottom: (sheetOpen ? sheetHeight : 44) + 8 + TIMELINE_H,
+            bottom: (sheetOpen ? sheetHeight : 44) + 12 + COMPACT_DOCK_H,
           }
         : {
             left: GUTTER + LEFT_W + GUTTER,
             right: GUTTER + RIGHT_W + GUTTER,
             top: dockTop,
-            bottom: BOTTOM_H + TIMELINE_H,
+            bottom: GUTTER + dockHeight,
           },
-    [dockTop, compact, sheetOpen, sheetHeight],
+    [dockTop, compact, sheetOpen, sheetHeight, dockHeight],
   );
 
   return (
@@ -205,13 +210,12 @@ export default function App() {
         layers={layers}
         safeArea={safeArea}
         observationsStale={observationsStale}
-        apiHealth={apiHealth}
         initialPose={initialPoseRef.current}
         exaggeration={exaggeration}
-        onExaggerationChange={setExaggeration}
         quality={quality}
         onQualityLevel={handleQualityLevel}
         compact={compact}
+        onInfo={setMapInfo}
         onApi={handleApi}
         onPoseChange={handlePose}
       />
@@ -230,9 +234,17 @@ export default function App() {
       {compact ? (
         <>
           <div
-            className="absolute z-10"
+            className="absolute z-10 flex flex-col gap-2 @container"
             style={{ left: 8, right: 8, bottom: (sheetOpen ? sheetHeight : 44) + 12 }}
           >
+            <div className="flex items-center gap-2">
+              <div className="min-w-0">
+                <SourceStatusBar state={apiHealth} compact />
+              </div>
+              <div className="ml-auto shrink-0">
+                <ExaggerationControl value={exaggeration} onChange={setExaggeration} />
+              </div>
+            </div>
             <TimelineBar atIso={atIso} onChange={setAtIso} />
           </div>
           <MobileSheet
@@ -316,20 +328,19 @@ export default function App() {
             top={dockTop}
           />
 
-          <div
-            className="absolute z-10"
-            style={{ left: safeArea.left, right: safeArea.right, bottom: BOTTOM_H + 8 }}
-          >
-            <div className="mx-auto max-w-2xl">
-              <TimelineBar atIso={atIso} onChange={setAtIso} />
-            </div>
-          </div>
-
           <BottomBar
             summary={observations.data?.summary ?? null}
             loading={observations.loading}
+            apiHealth={apiHealth}
+            mapInfo={mapInfo}
+            exaggeration={exaggeration}
+            onExaggerationChange={setExaggeration}
+            atIso={atIso}
+            onAtIsoChange={setAtIso}
             left={safeArea.left}
             right={safeArea.right}
+            bottom={GUTTER}
+            onHeight={setDockHeight}
           />
         </>
       )}

--- a/apps/web/src/components/layout/BottomBar.tsx
+++ b/apps/web/src/components/layout/BottomBar.tsx
@@ -1,30 +1,88 @@
+import { useLayoutEffect, useRef } from "react";
 import type { ObservationSummary } from "@siahra/shared-types";
-import { BRAND, DATA_ATTRIBUTION_TH } from "../../branding";
+import type { ApiHealthState } from "../../hooks/useApiHealth";
+import { ExaggerationControl } from "./ExaggerationControl";
+import type { MapInfo } from "./Map3DCanvas";
+import { MapAttribution } from "./MapAttribution";
+import { SourceStatusBar } from "./SourceStatusBar";
 import { StatStrip } from "./StatStrip";
+import { TimelineBar } from "./TimelineBar";
 
-/** Bottom dock between the side docks: stat tiles + copyright/attribution. */
+/**
+ * Bottom dock between the side docks. Everything shares the same left/right
+ * edges, top to bottom: source freshness + vertical scale, the history
+ * scrubber, the stat tiles, then provenance/copyright.
+ */
 export function BottomBar({
   summary,
   loading,
+  apiHealth,
+  mapInfo,
+  exaggeration,
+  onExaggerationChange,
+  atIso,
+  onAtIsoChange,
   left,
   right,
+  bottom,
+  onHeight,
 }: {
   summary: ObservationSummary | null;
   loading: boolean;
+  apiHealth: ApiHealthState;
+  mapInfo: MapInfo | null;
+  exaggeration: number;
+  onExaggerationChange: (f: number) => void;
+  atIso: string | null;
+  onAtIsoChange: (atIso: string | null) => void;
   left: number;
   right: number;
+  bottom: number;
+  /** Reports the rendered dock height so the map can keep the province clear of it. */
+  onHeight?: (px: number) => void;
 }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || !onHeight) return;
+    const report = () => onHeight(Math.round(el.getBoundingClientRect().height));
+    report();
+    const ro = new ResizeObserver(report);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [onHeight]);
+
   return (
     <div
-      className="pointer-events-none absolute bottom-3 flex flex-col items-end gap-1.5"
-      style={{ left, right }}
+      ref={ref}
+      className="pointer-events-none absolute z-10 flex flex-col gap-2 @container"
+      style={{ left, right, bottom }}
     >
+      {/* The status bar wraps its chips internally when the dock is narrow;
+          the scale picker stays pinned to the right edge. */}
+      <div className="pointer-events-auto flex items-center gap-2">
+        <div className="min-w-0">
+          {/* Dots only in a narrow dock; full labels once there is room. */}
+          <div className="@xl:hidden">
+            <SourceStatusBar state={apiHealth} compact />
+          </div>
+          <div className="hidden @xl:block">
+            <SourceStatusBar state={apiHealth} />
+          </div>
+        </div>
+        <div className="ml-auto shrink-0">
+          <ExaggerationControl value={exaggeration} onChange={onExaggerationChange} />
+        </div>
+      </div>
+      <div className="pointer-events-auto">
+        <TimelineBar atIso={atIso} onChange={onAtIsoChange} />
+      </div>
       <div className="pointer-events-auto">
         <StatStrip summary={summary} loading={loading} />
       </div>
-      <p className="truncate rounded-md bg-black/30 px-2 py-0.5 text-[10px] text-white/45 backdrop-blur-sm">
-        © {BRAND.copyrightYear} {BRAND.name} · {DATA_ATTRIBUTION_TH}
-      </p>
+      <div className="pointer-events-auto self-start">
+        <MapAttribution info={mapInfo} exaggeration={exaggeration} />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/layout/ExaggerationControl.tsx
+++ b/apps/web/src/components/layout/ExaggerationControl.tsx
@@ -1,0 +1,31 @@
+import { Segmented } from "../ui/Segmented";
+
+const EXAGGERATION_STEPS = [1, 2, 4, 8];
+
+/**
+ * Vertical exaggeration picker. Always on screen next to the map so an
+ * exaggerated view is never mistaken for real elevation.
+ */
+export function ExaggerationControl({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (factor: number) => void;
+}) {
+  return (
+    <div className="glass-soft flex h-8 shrink-0 items-center gap-2 rounded-xl pr-1 pl-3">
+      <span className="text-[11px] whitespace-nowrap text-[var(--color-fg-muted)]">ขยายแนวดิ่ง</span>
+      <Segmented
+        label="ขยายแนวดิ่ง"
+        value={value}
+        onChange={onChange}
+        options={EXAGGERATION_STEPS.map((f) => ({
+          value: f,
+          label: `${f}×`,
+          title: f === 1 ? "ความสูงจริง 1:1" : `ขยายความสูง ${f} เท่า (ไม่ใช่สัดส่วนจริง)`,
+        }))}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/MapAttribution.tsx
+++ b/apps/web/src/components/layout/MapAttribution.tsx
@@ -1,0 +1,32 @@
+import { BRAND, DATA_ATTRIBUTION_TH } from "../../branding";
+import type { MapInfo } from "./Map3DCanvas";
+
+/**
+ * Terrain/imagery provenance + copyright, one quiet block under the dock.
+ * The vertical-scale note stays here so an exaggerated view is never
+ * mistaken for real relief.
+ */
+export function MapAttribution({ info, exaggeration }: { info: MapInfo | null; exaggeration: number }) {
+  const parts: string[] = [];
+  if (info) {
+    parts.push(
+      `ภูมิประเทศ Copernicus GLO-30 (${info.demType}) · ${
+        info.nativeCellSizeM ? `${info.nativeCellSizeM} ม./เซลล์ (LOD ตามระยะกล้อง)` : `${info.cellSizeM} ม./เซลล์`
+      }`,
+    );
+    parts.push(`มาตราส่วนแนวดิ่ง ${exaggeration === 1 ? "1:1 (จริง)" : `${exaggeration}:1 (ขยายแนวดิ่ง)`}`);
+    parts.push(
+      `อาคาร OSM ${info.buildingCount.toLocaleString("th-TH")} หลัง${info.coverage === "urban-core" ? " (เฉพาะเขตเมือง)" : ""}`,
+    );
+    if (info.stationCount > 0) parts.push(`สถานีตรวจวัด ${info.stationCount.toLocaleString("th-TH")} สถานี`);
+    if (info.imagery) parts.push(`ภาพดาวเทียม © ${info.imagery.attribution}`);
+  }
+  return (
+    <div className="flex flex-col gap-0.5 rounded-lg bg-black/35 px-2.5 py-1 text-[10px] leading-snug text-white/55 backdrop-blur-sm">
+      {parts.length > 0 ? <p>{parts.join(" · ")}</p> : null}
+      <p className="text-white/45">
+        © {BRAND.copyrightYear} {BRAND.name} · {DATA_ATTRIBUTION_TH}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/MapViewport.tsx
+++ b/apps/web/src/components/layout/MapViewport.tsx
@@ -8,12 +8,10 @@ import type {
   ObservationsResponse,
   RadarFramesResponse,
 } from "@siahra/shared-types";
-import type { ApiHealthState } from "../../hooks/useApiHealth";
 import type { CameraPose, MapTool, SafeArea, SceneHandles } from "../../scene/setupScene";
 import { IconButton } from "../ui/Panel";
 import { Map3DCanvas, type MapApi, type MapInfo, type MapLayers } from "./Map3DCanvas";
 import type { QualityLevel, QualityMode } from "../../scene/quality";
-import { SourceStatusBar } from "./SourceStatusBar";
 
 const ZOOM_FACTOR = 0.75;
 
@@ -22,7 +20,6 @@ function handlesHeading(h: SceneHandles): number {
   const dz = h.camera.position.z - h.controls.target.z;
   return ((Math.atan2(dx, dz) * 180) / Math.PI + 360) % 360;
 }
-const EXAGGERATION_STEPS = [1, 2, 4, 8];
 
 export function MapViewport({
   aoiId,
@@ -36,10 +33,8 @@ export function MapViewport({
   layers,
   safeArea,
   observationsStale = false,
-  apiHealth,
   initialPose,
   exaggeration,
-  onExaggerationChange,
   quality,
   onQualityLevel,
   compact = false,
@@ -49,7 +44,6 @@ export function MapViewport({
 }: {
   compact?: boolean;
   exaggeration: number;
-  onExaggerationChange: (f: number) => void;
   quality: QualityMode;
   onQualityLevel?: (level: QualityLevel, mode: QualityMode) => void;
   aoiId: string;
@@ -67,11 +61,9 @@ export function MapViewport({
   layers: MapLayers;
   safeArea: SafeArea;
   observationsStale?: boolean;
-  apiHealth?: ApiHealthState;
   onInfo?: (info: MapInfo | null) => void;
 }) {
   const [tool, setTool] = useState<MapTool>("select");
-  const setExaggeration = onExaggerationChange;
   const [heading, setHeading] = useState(0);
   const [fullscreen, setFullscreen] = useState(false);
   const [info, setInfo] = useState<MapInfo | null>(null);
@@ -215,50 +207,6 @@ export function MapViewport({
         </div>
       </div>
 
-      {/* Attribution + vertical scale — always visible so an exaggerated
-          view is never mistaken for real elevation. */}
-      <div
-        className="pointer-events-none absolute flex max-w-[min(60vw,720px)] flex-col gap-1.5"
-        style={{ bottom: safeArea.bottom + 6, left: leftEdge }}
-      >
-        {apiHealth ? (
-          <div className="pointer-events-auto self-start">
-            <SourceStatusBar state={apiHealth} compact={compact} />
-          </div>
-        ) : null}
-        <div className="pointer-events-auto glass-soft flex items-center gap-1 self-start rounded-xl p-1">
-          <span className="px-1.5 text-[11px] text-[var(--color-fg-subtle)]">ขยายแนวดิ่ง</span>
-          {EXAGGERATION_STEPS.map((f) => (
-            <button
-              key={f}
-              type="button"
-              onClick={() => setExaggeration(f)}
-              aria-pressed={exaggeration === f}
-              className={`cursor-pointer rounded-md px-2 py-1 text-[11px] tabular-nums transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)] ${
-                exaggeration === f
-                  ? "bg-[var(--color-accent)] text-white"
-                  : "text-[var(--color-fg-muted)] hover:bg-white/8 hover:text-[var(--color-fg)]"
-              }`}
-            >
-              {f}×
-            </button>
-          ))}
-        </div>
-        {info && !compact ? (
-          <p className="rounded-lg bg-black/35 px-2.5 py-1 text-[10.5px] leading-snug text-white/65 backdrop-blur-sm">
-            ภูมิประเทศ Copernicus GLO-30 ({info.demType}) ·{" "}
-            {info.nativeCellSizeM
-              ? `${info.nativeCellSizeM} ม./เซลล์ (LOD ตามระยะกล้อง)`
-              : `${info.cellSizeM} ม./เซลล์`}
-            {info.imagery ? ` · ภาพดาวเทียม © ${info.imagery.attribution}` : ""}
-            {" · "}อาคาร OSM {info.buildingCount.toLocaleString("th-TH")} หลัง
-            {info.coverage === "urban-core" ? " (เฉพาะเขตเมือง)" : ""}
-            {info.stationCount > 0 ? ` · สถานีตรวจวัด ${info.stationCount.toLocaleString("th-TH")} สถานี` : ""}
-            {" · "}มาตราส่วนแนวดิ่ง{" "}
-            {exaggeration === 1 ? "1:1 (จริง)" : `${exaggeration}:1 (ขยายแนวดิ่ง)`}
-          </p>
-        ) : null}
-      </div>
     </div>
   );
 }

--- a/apps/web/src/components/layout/SourceStatusBar.tsx
+++ b/apps/web/src/components/layout/SourceStatusBar.tsx
@@ -26,7 +26,7 @@ function ageLabel(iso: string | null): string {
 export function SourceStatusBar({ state, compact = false }: { state: ApiHealthState; compact?: boolean }) {
   if (state.apiDown) {
     return (
-      <div className="glass-soft flex items-center gap-2 rounded-xl px-3 py-1.5 text-[11px]">
+      <div className="glass-soft flex min-h-8 items-center gap-2 rounded-xl px-3 py-1 text-[11px]">
         <span className="h-2 w-2 animate-pulse rounded-full bg-[var(--color-danger)]" aria-hidden="true" />
         <span className="text-[var(--color-danger)]">เชื่อมต่อ API ไม่ได้</span>
         <span className="text-[var(--color-fg-subtle)]">— แผนที่ยังใช้ได้ แต่ไม่มีข้อมูลตรวจวัดสด</span>
@@ -38,7 +38,7 @@ export function SourceStatusBar({ state, compact = false }: { state: ApiHealthSt
   if (compact) {
     // Dots only; the label lives in the tooltip.
     return (
-      <div className="glass-soft flex items-center gap-2 rounded-xl px-2.5 py-1.5 text-[11px]">
+      <div className="glass-soft flex h-8 items-center gap-2 rounded-xl px-3 text-[11px]">
         {sources.map((s) => (
           <span key={s.id} className={`h-2.5 w-2.5 rounded-full ${HEALTH_META[s.health].dot}`} title={`${s.labelTh}: ${HEALTH_META[s.health].label} · ${ageLabel(s.fetchedAt)}`} />
         ))}
@@ -47,12 +47,16 @@ export function SourceStatusBar({ state, compact = false }: { state: ApiHealthSt
     );
   }
   return (
-    <div className="glass-soft flex flex-wrap items-center gap-x-4 gap-y-1 rounded-xl px-3 py-1.5 text-[11px]">
+    <div className="glass-soft flex min-h-8 min-w-0 flex-wrap items-center gap-x-3.5 gap-y-1 rounded-xl px-3 py-1 text-[11px]">
       {sources.map((s) => {
         const meta = HEALTH_META[s.health];
         return (
-          <span key={s.id} className="flex items-center gap-1.5" title={s.lastError ?? undefined}>
-            <span className={`h-2 w-2 rounded-full ${meta.dot}`} aria-hidden="true" />
+          <span
+            key={s.id}
+            className="flex items-center gap-1.5 whitespace-nowrap"
+            title={s.lastError ?? `${s.labelTh}: ${meta.label} · ${ageLabel(s.fetchedAt)}`}
+          >
+            <span className={`h-2 w-2 shrink-0 rounded-full ${meta.dot}`} aria-hidden="true" />
             <span className="text-[var(--color-fg)]">{s.labelTh}</span>
             <span className={s.health === "ok" ? "text-[var(--color-fg-subtle)]" : "text-[var(--color-risk-medium)]"}>
               {s.health === "ok" ? `อัปเดต ${ageLabel(s.fetchedAt)}` : meta.label}

--- a/apps/web/src/components/layout/StatStrip.tsx
+++ b/apps/web/src/components/layout/StatStrip.tsx
@@ -15,7 +15,7 @@ function Tile({
   emphasis?: boolean;
 }) {
   return (
-    <div className="glass flex min-w-[9.5rem] items-center gap-3 rounded-2xl px-3.5 py-2.5">
+    <div className="glass flex min-w-0 items-center gap-3 rounded-2xl px-3.5 py-2.5">
       <div
         className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${
           emphasis
@@ -25,10 +25,12 @@ function Tile({
       >
         {icon}
       </div>
-      <div className="leading-tight">
-        <p className="text-[11px] whitespace-nowrap text-[var(--color-fg-subtle)]">{label}</p>
+      <div className="min-w-0 leading-tight">
+        <p className="truncate text-[11px] text-[var(--color-fg-subtle)]" title={label}>
+          {label}
+        </p>
         <p
-          className={`text-lg font-bold tabular-nums ${
+          className={`truncate text-lg font-bold tabular-nums ${
             emphasis ? "text-[var(--color-risk-high)]" : "text-[var(--color-fg)]"
           }`}
         >
@@ -40,6 +42,9 @@ function Tile({
   );
 }
 
+/** Two columns when the dock is narrow, four when there is room. */
+const GRID = "grid grid-cols-2 gap-2 @xl:grid-cols-4";
+
 /** Bottom stat tiles: latest observed values for the selected province. */
 export function StatStrip({
   summary,
@@ -50,10 +55,10 @@ export function StatStrip({
 }) {
   if (loading && !summary) {
     return (
-      <div className="flex items-center gap-2">
+      <div className={GRID}>
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="glass flex min-w-[9.5rem] items-center gap-3 rounded-2xl px-3.5 py-2.5">
-            <div className="h-9 w-9 animate-pulse rounded-xl bg-white/8" />
+          <div key={i} className="glass flex min-w-0 items-center gap-3 rounded-2xl px-3.5 py-2.5">
+            <div className="h-9 w-9 shrink-0 animate-pulse rounded-xl bg-white/8" />
             <div className="flex flex-col gap-1.5">
               <div className="h-2.5 w-20 animate-pulse rounded bg-white/8" />
               <div className="h-4 w-12 animate-pulse rounded bg-white/8" />
@@ -66,7 +71,7 @@ export function StatStrip({
 
   if (!summary) {
     return (
-      <div className="glass-soft rounded-2xl px-3.5 py-2.5 text-xs text-[var(--color-fg-subtle)]">
+      <div className="glass-soft rounded-2xl px-3.5 py-2.5 text-center text-xs text-[var(--color-fg-subtle)]">
         ไม่มีข้อมูลตรวจวัด
       </div>
     );
@@ -76,7 +81,7 @@ export function StatStrip({
     n === null ? "—" : n.toLocaleString("th-TH", { maximumFractionDigits: digits });
 
   return (
-    <div className="flex items-center gap-2">
+    <div className={GRID}>
       <Tile
         icon={<CloudRain size={17} aria-hidden="true" />}
         label="สถานีวัดน้ำฝน"

--- a/apps/web/src/components/layout/TimelineBar.tsx
+++ b/apps/web/src/components/layout/TimelineBar.tsx
@@ -1,14 +1,20 @@
 import { Pause, Play, RotateCcw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Segmented } from "../ui/Segmented";
 
-/** Selectable playback windows: hours and slider step in minutes. */
-const RANGES: { hours: number; stepMin: number; label: string }[] = [
-  { hours: 72, stepMin: 30, label: "72 ชม." },
-  { hours: 7 * 24, stepMin: 60, label: "7 วัน" },
-  { hours: 30 * 24, stepMin: 180, label: "30 วัน" },
+/** Selectable playback windows: hours, slider step in minutes, tick marks (hours ago). */
+const RANGES: { hours: number; stepMin: number; label: string; ticks: number[] }[] = [
+  { hours: 72, stepMin: 30, label: "72 ชม.", ticks: [72, 48, 24, 0] },
+  { hours: 7 * 24, stepMin: 60, label: "7 วัน", ticks: [168, 120, 72, 24, 0] },
+  { hours: 30 * 24, stepMin: 180, label: "30 วัน", ticks: [720, 480, 240, 0] },
 ];
 /** Beyond this the backend reads from the long-term archive (R2). */
 const HOT_HOURS = 7 * 24;
+
+function tickLabel(h: number): string {
+  if (h === 0) return "ตอนนี้";
+  return h >= 48 ? `-${h / 24} วัน` : `-${h} ชม.`;
+}
 
 /**
  * Scrub the map back through *observed* water levels (ThaiWater 10-minute
@@ -25,8 +31,9 @@ export function TimelineBar({
 }) {
   const [playing, setPlaying] = useState(false);
   const [rangeIdx, setRangeIdx] = useState(0);
-  const RANGE_HOURS = RANGES[rangeIdx].hours;
-  const STEP_MIN = RANGES[rangeIdx].stepMin;
+  const range = RANGES[rangeIdx];
+  const RANGE_HOURS = range.hours;
+  const STEP_MIN = range.stepMin;
   const steps = (RANGE_HOURS * 60) / STEP_MIN;
   const ageHours = atIso ? (Date.now() - Date.parse(atIso)) / 3600000 : 0;
   const fromArchive = ageHours > HOT_HOURS;
@@ -60,14 +67,15 @@ export function TimelineBar({
   }, [playing, clamped]);
 
   const label = useMemo(() => {
-    if (!atIso) return "ปัจจุบัน (ค่าล่าสุด)";
+    if (!atIso) return "ปัจจุบัน · ค่าล่าสุด";
     return new Date(atIso).toLocaleString("th-TH", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" }) + " น.";
   }, [atIso]);
 
-  const ticks = rangeIdx === 0 ? [72, 48, 24, 0] : rangeIdx === 1 ? [168, 120, 72, 24, 0] : [720, 480, 240, 0];
+  const live = atIso === null;
+  const progress = (clamped / steps) * 100;
 
   return (
-    <div className="glass flex items-center gap-3 rounded-2xl px-3 py-2">
+    <div className="glass flex items-center gap-3 rounded-2xl py-2 pr-4 pl-2.5">
       <div className="flex shrink-0 items-center gap-1">
         <button
           type="button"
@@ -75,10 +83,11 @@ export function TimelineBar({
             if (clamped >= steps) setStep(0);
             setPlaying((p) => !p);
           }}
-          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-[var(--color-accent)] text-white hover:bg-blue-500"
+          className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full bg-[var(--color-accent)] text-white shadow-[0_2px_10px_rgba(59,130,246,0.45)] transition-colors hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
           aria-label={playing ? "หยุด" : "เล่นย้อนหลัง"}
+          title={playing ? "หยุด" : "เล่นย้อนหลัง"}
         >
-          {playing ? <Pause size={14} /> : <Play size={14} className="translate-x-px" />}
+          {playing ? <Pause size={15} /> : <Play size={15} className="translate-x-px" />}
         </button>
         <button
           type="button"
@@ -86,47 +95,53 @@ export function TimelineBar({
             setPlaying(false);
             onChange(null);
           }}
-          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-[var(--color-fg-muted)] hover:bg-white/8 hover:text-white"
+          disabled={live}
+          className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full text-[var(--color-fg-muted)] transition-colors hover:bg-white/8 hover:text-white disabled:cursor-default disabled:opacity-35 disabled:hover:bg-transparent"
           aria-label="กลับสู่ปัจจุบัน"
           title="กลับสู่ปัจจุบัน"
         >
-          <RotateCcw size={14} />
+          <RotateCcw size={15} />
         </button>
       </div>
+
       <div className="min-w-0 flex-1">
-        <div className="flex items-baseline justify-between text-[11px]">
-          <span className="flex items-center gap-2 font-medium text-[var(--color-fg)]">
-            ระดับน้ำย้อนหลัง
-            <span className="flex rounded-md bg-white/5 p-0.5">
-              {RANGES.map((r, i) => (
-                <button
-                  key={r.hours}
-                  type="button"
-                  onClick={() => {
-                    setPlaying(false);
-                    setRangeIdx(i);
-                    onChange(null);
-                  }}
-                  aria-pressed={rangeIdx === i}
-                  className={`cursor-pointer rounded px-1.5 py-0.5 text-[10px] ${
-                    rangeIdx === i ? "bg-[var(--color-accent)] text-white" : "text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]"
-                  }`}
-                >
-                  {r.label}
-                </button>
-              ))}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="shrink-0 text-xs font-semibold text-[var(--color-fg)]">ระดับน้ำย้อนหลัง</span>
+            <Segmented
+              label="ช่วงเวลาย้อนหลัง"
+              value={rangeIdx}
+              onChange={(i) => {
+                setPlaying(false);
+                setRangeIdx(i);
+                onChange(null);
+              }}
+              options={RANGES.map((r, i) => ({ value: i, label: r.label }))}
+            />
+            <span className="hidden truncate text-[11px] text-[var(--color-fg-subtle)] @2xl:inline">
+              ค่าตรวจวัดจริง · ไม่ใช่พยากรณ์
             </span>
-            <span className="text-[var(--color-fg-subtle)]">· ค่าตรวจวัดจริง ไม่ใช่พยากรณ์</span>
             {fromArchive ? (
-              <span className="rounded bg-[var(--color-risk-medium)]/15 px-1.5 text-[10px] text-[var(--color-risk-medium)]">
-                จากคลังถาวร (รายชั่วโมง)
+              <span className="shrink-0 rounded-md bg-[var(--color-risk-medium)]/15 px-1.5 py-0.5 text-[10px] leading-none whitespace-nowrap text-[var(--color-risk-medium)]">
+                จากคลังถาวร · รายชั่วโมง
               </span>
             ) : null}
-          </span>
-          <span className={`tabular-nums ${atIso ? "text-[var(--color-risk-medium)]" : "text-[var(--color-success)]"}`}>
+          </div>
+          <span
+            className={`ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums ${
+              live ? "text-[var(--color-success)]" : "text-[var(--color-risk-medium)]"
+            }`}
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full ${
+                live ? "bg-[var(--color-success)] shadow-[0_0_6px_rgba(34,197,94,0.9)]" : "bg-[var(--color-risk-medium)]"
+              }`}
+              aria-hidden="true"
+            />
             {label}
           </span>
         </div>
+
         <input
           type="range"
           min={0}
@@ -138,12 +153,29 @@ export function TimelineBar({
             setStep(Number(e.target.value));
           }}
           aria-label="เลื่อนเวลา"
-          className="mt-1 w-full accent-[var(--color-accent)]"
+          aria-valuetext={label}
+          className="range-slider mt-2 w-full"
+          style={{ "--range-progress": `${progress}%` } as React.CSSProperties}
         />
-        <div className="flex justify-between text-[10px] text-[var(--color-fg-subtle)]">
-          {ticks.map((h) => (
-            <span key={h}>{h === 0 ? "ตอนนี้" : h >= 48 ? `-${h / 24} วัน` : `-${h} ชม.`}</span>
-          ))}
+
+        {/* Ticks sit at their true position along the track, not evenly spaced. */}
+        <div className="relative mt-0.5 h-3.5 text-[10px] leading-none text-[var(--color-fg-subtle)]">
+          {range.ticks.map((h, i) => {
+            const pct = (1 - h / RANGE_HOURS) * 100;
+            const last = i === range.ticks.length - 1;
+            return (
+              <span
+                key={h}
+                className="absolute top-0 whitespace-nowrap tabular-nums"
+                style={{
+                  left: `${pct}%`,
+                  transform: i === 0 ? "none" : last ? "translateX(-100%)" : "translateX(-50%)",
+                }}
+              >
+                {tickLabel(h)}
+              </span>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/ui/Segmented.tsx
+++ b/apps/web/src/components/ui/Segmented.tsx
@@ -1,0 +1,43 @@
+/** Small pill-style segmented control (range picker, exaggeration steps). */
+export function Segmented<T extends string | number>({
+  options,
+  value,
+  onChange,
+  label,
+  className = "",
+}: {
+  options: { value: T; label: string; title?: string }[];
+  value: T;
+  onChange: (value: T) => void;
+  /** Accessible group name. */
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className={`flex items-center gap-0.5 rounded-lg bg-white/6 p-0.5 ring-1 ring-white/8 ring-inset ${className}`}
+    >
+      {options.map((o) => {
+        const active = o.value === value;
+        return (
+          <button
+            key={String(o.value)}
+            type="button"
+            onClick={() => onChange(o.value)}
+            aria-pressed={active}
+            title={o.title}
+            className={`h-6 cursor-pointer rounded-md px-2 text-[11px] leading-none whitespace-nowrap tabular-nums transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--color-accent)] ${
+              active
+                ? "bg-[var(--color-accent)] text-white shadow-[0_1px_6px_rgba(59,130,246,0.45)]"
+                : "text-[var(--color-fg-muted)] hover:bg-white/8 hover:text-[var(--color-fg)]"
+            }`}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -175,3 +175,65 @@ body {
   white-space: nowrap;
   pointer-events: none;
 }
+
+/* Timeline scrubber: slim track with a filled progress portion. */
+.range-slider {
+  --range-progress: 100%;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 16px;
+  margin: 0;
+  background: transparent;
+  cursor: pointer;
+}
+.range-slider:focus-visible {
+  outline: none;
+}
+.range-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--color-accent) 0%,
+    var(--color-accent) var(--range-progress),
+    rgba(255, 255, 255, 0.14) var(--range-progress),
+    rgba(255, 255, 255, 0.14) 100%
+  );
+}
+.range-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-top: -5px;
+  border-radius: 999px;
+  background: #fff;
+  border: 2px solid var(--color-accent);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  transition: transform 120ms ease;
+}
+.range-slider:hover::-webkit-slider-thumb,
+.range-slider:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.15);
+}
+.range-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.4);
+}
+.range-slider::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+}
+.range-slider::-moz-range-progress {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--color-accent);
+}
+.range-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #fff;
+  border: 2px solid var(--color-accent);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## สรุป
แถบด้านล่างของแผนที่เดิมมี overlay 6 ชิ้น จัดชิด 3 แบบต่างกัน (สถานะแหล่งข้อมูล/ขยายแนวดิ่ง/attribution ชิดซ้าย, timeline อยู่กลาง, การ์ดสถิติ/© ชิดขวา) จึงดูไม่เป็นสัดส่วน — PR นี้จัดใหม่เป็น **dock เดียว** ที่ใช้ขอบซ้าย/ขวาเดียวกับแผงด้านข้าง เรียงจากบนลงล่าง:

1. **แถบสถานะแหล่งข้อมูล** (ย่อเป็นจุดอัตโนมัติเมื่อ dock แคบ ผ่าน `@container`) + **ตัวเลือกขยายแนวดิ่ง** ตรึงขวา — สูงเท่ากัน
2. **Timeline** เต็มความกว้าง dock: ตัวเลือกช่วง (72 ชม./7 วัน/30 วัน) ใช้ `Segmented` ตัวเดียวกับปุ่มขยายแนวดิ่ง, slider แบบ custom มีแถบ progress, ป้าย tick วางตามตำแหน่งจริงบนแกนเวลา (ช่วง 7 วันเดิม tick ไม่ได้ห่างเท่ากันแต่ใช้ `justify-between`), จุดสีเขียว/เหลืองบอกสด/ย้อนหลัง, ปุ่มรีเซ็ต disabled ตอนสด
3. **การ์ดสถิติ** เป็น grid 4 คอลัมน์เต็มความกว้าง (2 คอลัมน์เมื่อแคบ)
4. **ที่มาข้อมูลภูมิประเทศ + ©** รวมเป็นบล็อกเดียว (ยังบอกมาตราส่วนแนวดิ่งตามกติกา data honesty)

โค้ด: `MapViewport` เลิก render กองด้านล่าง; `App` ถือ `MapInfo` และรับความสูงจริงของ dock (ResizeObserver) ไปตั้ง safe area ของกล้อง; โหมด compact ซ้อนแถวสถานะเหนือ timeline แบบเดียวกัน ไฟล์ใหม่: `ui/Segmented.tsx`, `layout/ExaggerationControl.tsx`, `layout/MapAttribution.tsx`

## ภาพหน้าจอ
**ก่อน**
![bottom-dock-before](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-Polish-UI/bottom-dock-before.png)

**หลัง (1536×960)**
![bottom-dock-after](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-Polish-UI/bottom-dock-after.png)

**dock แคบ (1180 px)** — สถานะย่อเป็นจุด, การ์ด 2 คอลัมน์
![bottom-dock-narrow](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-Polish-UI/bottom-dock-narrow.png)

**compact (430 px)**
![bottom-dock-mobile](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-Polish-UI/bottom-dock-mobile.png)

## ตรวจแล้ว
- `npx tsc -b`, `npx oxlint src`, `npm run build -w apps/web` ผ่าน
- ลอง scrub timeline ด้วยคีย์บอร์ดใน headless: progress fill / ป้ายเวลาย้อนหลังสีเหลือง / ปุ่มรีเซ็ตทำงาน

🤖 Generated with [Claude Code](https://claude.com/claude-code)