### PR TITLE
ci: auto-deploy web/api Workers on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy
+
+# Runs after a merge lands on `main` (CI already gated the PR, so this trusts
+# that Lint/TypeScript/Build passed) and deploys only the Worker(s) whose
+# files actually changed — same split as `npm run deploy:web`/`deploy:api`
+# in docs/deploy.md, just no longer something a human has to remember to run.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed apps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+      api: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - id: filter
+        run: |
+          changed=$(git diff --name-only HEAD^ HEAD)
+          echo "changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -qE '^(apps/web/|packages/shared-types/)'; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$changed" | grep -qE '^(apps/api/|packages/shared-types/)'; then
+            echo "api=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-web:
+    name: Deploy web
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run deploy:web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  deploy-api:
+    name: Deploy api
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run deploy:api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -39,7 +39,9 @@ R2 bucket `siahra-geodata` ตรวจแล้วว่า `/api/v1/health` �
 ยังปล่อยว่าง (same-origin เท่านั้น) ได้ตามเดิม
 
 deploy แยกกันได้จริง — แก้ UI แล้ว deploy web ไม่แตะ Durable Objects, แก้ API แล้ว deploy api
-ไม่ต้องอัปโหลด asset bundle ~310 MB ซ้ำ:
+ไม่ต้องอัปโหลด asset bundle ~310 MB ซ้ำ **และตอนนี้ `.github/workflows/deploy.yml` ทำให้อัตโนมัติแล้ว**
+— merge เข้า `main` แล้ว job จะ diff ไฟล์ที่เปลี่ยนกับ `HEAD^` แล้วสั่ง deploy เฉพาะ Worker ที่แตะ
+(ต้องตั้ง repo secret `CLOUDFLARE_API_TOKEN` และ `CLOUDFLARE_ACCOUNT_ID` ก่อนถึงจะรันผ่าน) รันมือได้เหมือนเดิมถ้าต้องการ:
 ```bash
 npm run deploy:web    # build apps/web แล้ว wrangler deploy ใน apps/web
 npm run deploy:api    # wrangler deploy ใน apps/api (ไม่ต้องมี dist)


### PR DESCRIPTION
## Summary
- Deploys have always been a manual `npm run deploy:web`/`deploy:api` step (docs/deploy.md). During today's DO rows_written outage, the fix (PR #13) sat merged to `main` for ~45 minutes without anyone deploying it, purely because merging isn't the same as deploying and it's easy to forget the extra step mid-incident.
- New `.github/workflows/deploy.yml` triggers on push to `main`, diffs the merge commit against its parent, and runs `npm run deploy:web` / `deploy:api` only for the Worker(s) whose files actually changed (`apps/web/**` / `apps/api/**` / `packages/shared-types/**`) — same split already documented in `docs/deploy.md` §0.1.
- Not added to `.github/rulesets/main.json` required checks — it only triggers on `push: branches: [main]`, never on `pull_request`, so it can't block a PR from merging.
- `docs/deploy.md` updated with a note that this now happens automatically, manual commands still documented as a fallback.

## Required setup before this can run
This repo currently has **no secrets configured** (`gh secret list` is empty). Before merging, add:
- `CLOUDFLARE_API_TOKEN` — a dedicated CI token scoped to Workers Scripts/Routes edit (not a personal OAuth login, which tends to carry much broader account permissions than a CI job needs)
- `CLOUDFLARE_ACCOUNT_ID`

via `gh secret set CLOUDFLARE_API_TOKEN` / `gh secret set CLOUDFLARE_ACCOUNT_ID`, or the repo Settings → Secrets UI.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Add the two secrets, then merge and confirm a push touching `apps/api/**` deploys only `deploy-api` (not `deploy-web`)
- [ ] Confirm a docs-only change (no `apps/**` touched) triggers neither deploy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)