### PR TITLE
ui: เพิ่มความทึบของการ์ด/แผงลอยเหนือแผนที่ให้อ่านง่ายขึ้น

### DIFF
--- a/apps/web/src/components/layout/Map3DCanvas.tsx
+++ b/apps/web/src/components/layout/Map3DCanvas.tsx
@@ -836,7 +836,7 @@ export function Map3DCanvas({
       {state.status === "loading" ||
       imageryProgress !== null ||
       (tileStats !== null && tileStats.visible === 0 && tileStats.loading + tileStats.pending > 0) ? (
-        <div className="pointer-events-none absolute top-24 left-1/2 flex -translate-x-1/2 items-center gap-3 rounded-full border border-white/10 bg-black/45 px-4 py-2 shadow-lg backdrop-blur-md">
+        <div className="pointer-events-none absolute top-24 left-1/2 flex -translate-x-1/2 items-center gap-3 rounded-full border border-white/10 bg-black/80 px-4 py-2 shadow-lg backdrop-blur-md">
           <div
             className="h-4 w-4 animate-spin rounded-full border-2 border-white/20 border-t-[var(--color-accent)]"
             aria-hidden="true"
@@ -877,7 +877,7 @@ export function Map3DCanvas({
 
       {state.status === "error" ? (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <p className="max-w-sm rounded-xl border border-red-400/30 bg-black/50 px-4 py-3 text-center text-sm text-red-300 backdrop-blur-md">
+          <p className="max-w-sm rounded-xl border border-red-400/30 bg-black/80 px-4 py-3 text-center text-sm text-red-300 backdrop-blur-md">
             {state.message}
           </p>
         </div>

--- a/apps/web/src/components/layout/MapAttribution.tsx
+++ b/apps/web/src/components/layout/MapAttribution.tsx
@@ -22,7 +22,7 @@ export function MapAttribution({ info, exaggeration }: { info: MapInfo | null; e
     if (info.imagery) parts.push(`ภาพดาวเทียม © ${info.imagery.attribution}`);
   }
   return (
-    <div className="flex flex-col gap-0.5 rounded-lg bg-black/35 px-2.5 py-1 text-[10px] leading-snug text-white/55 backdrop-blur-sm">
+    <div className="flex flex-col gap-0.5 rounded-lg bg-black/70 px-2.5 py-1 text-[10px] leading-snug text-white/55 backdrop-blur-sm">
       {parts.length > 0 ? <p>{parts.join(" · ")}</p> : null}
       <p className="text-white/45">
         © {BRAND.copyrightYear} {BRAND.name} · {DATA_ATTRIBUTION_TH}

--- a/apps/web/src/components/layout/MapViewport.tsx
+++ b/apps/web/src/components/layout/MapViewport.tsx
@@ -157,7 +157,7 @@ export function MapViewport({
           มุมมอง 3 มิติ · ภูมิประเทศจริง
         </p>
         {info?.radarFrameAt ? (
-          <p className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-black/40 px-2.5 py-0.5 text-[11px] text-white/85 backdrop-blur-sm">
+          <p className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-black/70 px-2.5 py-0.5 text-[11px] text-white/85 backdrop-blur-sm">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" aria-hidden="true" />
             เรดาร์ฝน TMD{" "}
             {new Date(info.radarFrameAt).toLocaleTimeString("th-TH", { hour: "2-digit", minute: "2-digit" })} น.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -87,21 +87,21 @@ body {
 
 /* Floating glass panels over the map. */
 .glass {
-  background: rgba(10, 16, 30, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.09);
+  background: rgba(9, 14, 27, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.11);
   box-shadow:
-    0 12px 40px rgba(0, 0, 0, 0.45),
+    0 12px 40px rgba(0, 0, 0, 0.55),
     inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(18px) saturate(140%);
-  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
 }
 
 .glass-soft {
-  background: rgba(10, 16, 30, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  background: rgba(9, 14, 27, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
 }
 
 /* CSS2D labels anchored to scene points. */
@@ -112,7 +112,7 @@ body {
   gap: 1px;
   padding: 3px 8px 4px;
   border-radius: 8px;
-  background: rgba(8, 12, 22, 0.78);
+  background: rgba(8, 12, 22, 0.92);
   border: 1px solid rgba(255, 255, 255, 0.14);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(6px);
@@ -130,7 +130,7 @@ body {
   width: 8px;
   height: 8px;
   transform: translateX(-50%) rotate(45deg);
-  background: rgba(8, 12, 22, 0.78);
+  background: rgba(8, 12, 22, 0.92);
   border-right: 1px solid rgba(255, 255, 255, 0.14);
   border-bottom: 1px solid rgba(255, 255, 255, 0.14);
 }


### PR DESCRIPTION
การ์ดทุกใบที่ลอยอยู่เหนือแผนที่ใสเกินไป พอซูมเข้าจนภาพถ่ายดาวเทียมสว่าง ตัวอักษรบนการ์ดอ่านยากมาก

## แก้อะไร
ทุกแผงวิ่งผ่าน `.glass` / `.glass-soft` ใน `apps/web/src/index.css` จึงแก้ที่ต้นทาง:

- `.glass` (Panel, TopBar, Sidebar, TimelineBar, StatStrip, InfoPopup, MobileSheet): `rgba(10,16,30,.72)` → `rgba(9,14,27,.94)`, blur 18→20px, เงาเข้มขึ้น, ขอบ .09→.11
- `.glass-soft` (SourceStatusBar, ExaggerationControl, ปุ่มกล้อง/ซูม, ApiStatusFooter): `.55` → `.88`
- `.map-label` (ป้ายสถานีบนแผนที่ + หางลูกศร): `.78` → `.92`
- แถบดำลอยอีก 4 จุด: `MapAttribution` `bg-black/35→/70`, `MapViewport` `/40→/70`, `Map3DCanvas` `/45,/50→/80`

ไม่มีการเปลี่ยนตรรกะข้อมูลหรือข้อความใด ๆ — เป็นงานด้านการมองเห็นล้วน

## ตรวจแล้ว
`npx tsc -b` + `npx oxlint src` ผ่าน; ถ่ายภาพจาก dev server ด้วยกล้อง/เลเยอร์ชุดเดียวกับที่ผู้ใช้รายงาน (ซูมเข้ากรุงเทพจนภาพดาวเทียมสว่าง)

![after-opaque-cards](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-fix-transparent-ui/after-opaque-cards.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)