### PR TITLE
perf: หยุดเผา GPU ตอนแผนที่นิ่ง (พัดลมเงียบลง)

### DIFF
--- a/apps/web/src/components/layout/Map3DCanvas.tsx
+++ b/apps/web/src/components/layout/Map3DCanvas.tsx
@@ -331,10 +331,19 @@ export function Map3DCanvas({
         // Animated water shimmer / hazard pulse + label declutter.
         const h = handles;
         const frameDistance = h.controls.maxDistance / 2.2;
+        // LOD re-evaluation and label declutter are the CPU-heavy part of the
+        // frame. While the camera moves they must keep up with it, but on a
+        // still camera nothing they compute can change, so they drop to 10 Hz
+        // (a heartbeat that still picks up tiles streaming in).
+        const HEAVY_IDLE_INTERVAL_MS = 100;
+        let heavyAt = 0;
         handles.addTicker((t) => {
           terrain.material.uniforms.uTime.value = t;
           radarOverlay.tick(performance.now());
-          if (tree) {
+          const heavy =
+            h.isCameraActive() || performance.now() - heavyAt >= HEAVY_IDLE_INTERVAL_MS;
+          if (heavy) heavyAt = performance.now();
+          if (tree && heavy) {
             tree.update(h.camera, h.world.scale.y, container.clientHeight);
             const keys = tree.visibleTileKeys();
             const now = performance.now();
@@ -348,17 +357,19 @@ export function Map3DCanvas({
             1,
             THREE.MathUtils.smoothstep(d, 0.12, 0.45),
           );
-          const all: CSS2DObject[] = [];
-          const collect = (g: THREE.Object3D | null | undefined) =>
-            g?.traverse((o) => {
-              if (o instanceof CSS2DObject) all.push(o);
-            });
-          collect(labelsRef.current);
-          collect(floodLabelsRef.current);
-          collect(damsRef.current?.labels);
-          collect(quakesRef.current?.group);
-          if (all.length > 0) {
-            declutterLabels(all, h.camera, container.clientWidth, container.clientHeight);
+          if (heavy) {
+            const all: CSS2DObject[] = [];
+            const collect = (g: THREE.Object3D | null | undefined) =>
+              g?.traverse((o) => {
+                if (o instanceof CSS2DObject) all.push(o);
+              });
+            collect(labelsRef.current);
+            collect(floodLabelsRef.current);
+            collect(damsRef.current?.labels);
+            collect(quakesRef.current?.group);
+            if (all.length > 0) {
+              declutterLabels(all, h.camera, container.clientWidth, container.clientHeight);
+            }
           }
         });
 

--- a/apps/web/src/scene/setupScene.ts
+++ b/apps/web/src/scene/setupScene.ts
@@ -61,6 +61,12 @@ export interface SceneHandles {
   setShadows: (enabled: boolean) => void;
   /** Smoothed frame time in ms. */
   frameTimeMs: () => number;
+  /**
+   * True while the camera is moving (drag, zoom, damping, flyTo). Frames run
+   * at the full rate then and at a lower idle rate otherwise, so per-frame work
+   * that only matters when the view changes can be throttled on the same signal.
+   */
+  isCameraActive: () => boolean;
   /** Called every frame with elapsed seconds. Returns an unsubscribe. */
   addTicker: (fn: (timeS: number) => void) => () => void;
   /** Called with drawing-buffer size on resize (and once immediately). */
@@ -109,6 +115,10 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
   renderer.setClearColor(BG, 0);
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFShadowMap;
+  // The shadow map is re-rendered only when the fit actually changes (see
+  // fitShadowCamera) — otherwise a still camera would redraw the whole
+  // province into a 2048² depth buffer on every single frame.
+  renderer.shadowMap.autoUpdate = false;
   renderer.toneMapping = THREE.NeutralToneMapping;
   renderer.toneMappingExposure = 1.22;
   renderer.domElement.style.position = "absolute";
@@ -177,10 +187,22 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
   };
   sky.renderOrder = -10;
   scene.add(sky);
+
+  // Shadow-map refit state (see fitShadowCamera). Declared here because
+  // syncSky, which runs during setup, invalidates the baked map.
+  const shadowCamPos = new THREE.Vector3(Infinity, Infinity, Infinity);
+  const shadowTarget = new THREE.Vector3(Infinity, Infinity, Infinity);
+  let shadowFitAt = 0;
+  /** Set when something other than the camera invalidates the shadow map. */
+  let shadowDirty = true;
+  const SHADOW_HEARTBEAT_MS = 500;
+
   const syncSky = () => {
     const dir = new THREE.Vector3().subVectors(sun.position, sun.target.position).normalize();
     skyU.sunPosition.value.copy(dir);
     sky.scale.setScalar(camera.far * 0.85);
+    // Every caller has just moved the sun, so the baked shadow map is stale.
+    shadowDirty = true;
   };
   syncSky();
 
@@ -198,7 +220,11 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
     // Camera south of the target (+z) looking north => heading 0.
     return ((Math.atan2(dx, dz) * 180) / Math.PI + 360) % 360;
   };
+  // Anything that moves the camera (drag, zoom, damping, flyTo) marks the view
+  // "active" so the frame budget switches from the idle rate to the full rate.
+  let lastInteractionAt = performance.now();
   controls.addEventListener("change", () => {
+    lastInteractionAt = performance.now();
     const h = headingDeg();
     cameraFns.forEach((fn) => fn(h));
   });
@@ -277,6 +303,7 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
     const groundY = world.scale.y > 0 ? controls.target.y / world.scale.y : controls.target.y;
     exaggeration = factor;
     world.scale.y = factor;
+    shadowDirty = true; // geometry moved vertically, camera may not have
     const dy = groundY * factor - controls.target.y;
     controls.target.y += dy;
     camera.position.y += dy;
@@ -396,6 +423,7 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
     if (renderer.shadowMap.enabled === enabled) return;
     renderer.shadowMap.enabled = enabled;
     sun.castShadow = enabled;
+    shadowDirty = true;
     scene.traverse((o) => {
       const m = (o as THREE.Mesh).material as THREE.Material | THREE.Material[] | undefined;
       if (!m) return;
@@ -406,15 +434,30 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
   };
   let frameEma = 16;
   let lastFrameAt = performance.now();
+  let wasActive = false;
 
   /**
-   * Shadow "cascade-lite": every frame the single shadow camera is refitted
-   * around the orbit target with an extent tied to the viewing distance, so
-   * shadows are sharp when zoomed in and still cover the province from afar.
+   * Shadow "cascade-lite": the single shadow camera is refitted around the
+   * orbit target with an extent tied to the viewing distance, so shadows are
+   * sharp when zoomed in and still cover the province from afar.
+   *
+   * The refit (and the shadow-map redraw it implies) happens only when the
+   * camera actually moved, plus a slow heartbeat so tiles that stream in later
+   * still get baked. A still camera therefore costs no second draw pass.
    */
-  const fitShadowCamera = () => {
+  const fitShadowCamera = (now: number) => {
     if (!renderer.shadowMap.enabled) return;
     const dist = camera.position.distanceTo(controls.target);
+    const eps = Math.max(0.5, dist * 5e-4);
+    const moved =
+      shadowCamPos.distanceToSquared(camera.position) > eps * eps ||
+      shadowTarget.distanceToSquared(controls.target) > eps * eps;
+    if (!moved && !shadowDirty && now - shadowFitAt < SHADOW_HEARTBEAT_MS) return;
+    shadowCamPos.copy(camera.position);
+    shadowTarget.copy(controls.target);
+    shadowFitAt = now;
+    shadowDirty = false;
+    renderer.shadowMap.needsUpdate = true;
     const extent = THREE.MathUtils.clamp(dist * 1.6, 1500, frameRadius * 1.3);
     const dir = new THREE.Vector3().subVectors(sun.position, sun.target.position).normalize();
     sun.target.position.copy(controls.target);
@@ -434,12 +477,33 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
 
   const startMs = performance.now();
   let frameId = 0;
+  /**
+   * Frame budget. rAF fires at the display refresh — 120 Hz on a ProMotion
+   * MacBook — which doubles GPU work for no visible gain on a map. Frames are
+   * throttled to ACTIVE_FPS while the camera moves and IDLE_FPS once it
+   * settles; the rAF callback still runs (it is cheap) but the draw is skipped.
+   */
+  const ACTIVE_FPS = 60;
+  const IDLE_FPS = 30;
+  /** How long after the last camera change the view still counts as active. */
+  const ACTIVE_TAIL_MS = 400;
+  /** Slack so a 120 Hz cadence lands on every 2nd/4th frame, not every 3rd/5th. */
+  const BUDGET_SLACK_MS = 2;
+  let lastDrawAt = 0;
+
   const animate = () => {
     frameId = requestAnimationFrame(animate);
     const now = performance.now();
-    frameEma = frameEma * 0.9 + (now - lastFrameAt) * 0.1;
+    const active = fly !== null || now - lastInteractionAt < ACTIVE_TAIL_MS;
+    const budget = 1000 / (active ? ACTIVE_FPS : IDLE_FPS) - BUDGET_SLACK_MS;
+    if (now - lastDrawAt < budget) return;
+    lastDrawAt = now;
+    // Only interactive frames feed the quality heuristic: an idle frame is
+    // slow by design (we asked for 30 Hz) and must not trigger a downgrade.
+    if (active && wasActive) frameEma = frameEma * 0.9 + Math.min(now - lastFrameAt, 100) * 0.1;
+    wasActive = active;
     lastFrameAt = now;
-    fitShadowCamera();
+    fitShadowCamera(now);
     const t = (now - startMs) / 1000;
     if (fly) {
       const k = Math.min(1, (performance.now() - fly.start) / fly.duration);
@@ -501,6 +565,7 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
     setPixelRatio,
     setShadows,
     frameTimeMs: () => frameEma,
+    isCameraActive: () => fly !== null || performance.now() - lastInteractionAt < ACTIVE_TAIL_MS,
     addTicker: (fn) => {
       tickers.add(fn);
       return () => tickers.delete(fn);


### PR DESCRIPTION
## ปัญหา

เปิดเว็บทิ้งไว้เฉย ๆ แล้วพัดลม MacBook Pro ร้อง — แผนที่เผา GPU เต็มที่ทั้งที่กล้องนิ่งสนิท

1. `requestAnimationFrame` วิ่งตามรีเฟรชจอ = **120 Hz** บน ProMotion → งาน GPU สองเท่าของ 60 Hz โดยไม่ได้ภาพที่ดีขึ้น
2. `fitShadowCamera()` รันทุกเฟรมแบบไม่มีเงื่อนไข → three อบ shadow map 2048² ใหม่ **ทุกเฟรม** = วาด terrain + อาคาร + ต้นไม้ทั้งจังหวัดรอบที่สอง 120 ครั้ง/วินาที
3. `tree.update()` + tile update + `declutterLabels` (traverse ทุก CSS2DObject) รันทุกเฟรมบน CPU

`QualityManager` ช่วยไม่ได้เลย เพราะลดคุณภาพเมื่อ frame time > 33 ms เท่านั้น แต่ GPU M-series ทำ 8 ms ได้สบายที่คุณภาพสูงสุด มันเลยค้างที่ `high` ตลอด — **frame time ไม่ใช่สัญญาณของการกินไฟ** จึงไม่ไปยุ่งกับ threshold ของมัน

## สิ่งที่แก้

**`scene/setupScene.ts`**
- จำกัดเฟรมเรต: **60 fps ขณะขยับกล้อง / 30 fps ตอนนิ่ง** (rAF ยังวิ่งเพราะถูกมาก แต่ข้ามการ draw); เพิ่ม `isCameraActive()` ใน `SceneHandles`
- `shadowMap.autoUpdate = false` + refit เฉพาะเมื่อกล้องขยับเกิน epsilon หรือ heartbeat ทุก 500 ms (เพื่อรับ tile ที่สตรีมเข้ามาทีหลัง) พร้อม flag `shadowDirty` ตอนดวงอาทิตย์ / exaggeration / shadows toggle เปลี่ยน
- `frameEma` นับเฉพาะเฟรมตอนขยับ ไม่งั้น 30 fps ตอนนิ่งจะไปหลอกให้ `QualityManager` ลดคุณภาพเอง

**`components/layout/Map3DCanvas.tsx`**
- LOD + tile update + declutter: ทุกเฟรมขณะขยับกล้อง, **10 Hz ตอนนิ่ง** (`uTime` shimmer กับ radar tick ยังทุกเฟรมเหมือนเดิม)

## วัดผล (playwright + dev server)

| | ก่อน | หลัง |
|---|---|---|
| วาดตอนนิ่ง | ตามรีเฟรชจอ (120/s) | **30/s** |
| อบ shadow map | ทุกเฟรม (120/s) | **2/s** |
| ขณะลาก/ซูม | เต็มรีเฟรช | 59 fps, LOD รัน 118/118 เฟรม |

`npx tsc -b` และ `npx oxlint src` ผ่าน

## ไม่มีผลต่อภาพ → `no-screenshot`

ทั้งหมดเป็นการลด*ความถี่*ของงานที่ผลลัพธ์ไม่เปลี่ยน ไม่ได้ลดคุณภาพการเรนเดอร์ (pixel ratio, shadow map size, LOD split factor เท่าเดิมทุกค่า) ภาพนิ่งออกมาเหมือนเดิม และขณะขยับกล้อง LOD/label ยังอัปเดตทุกเฟรมเช่นเดิม

หมายเหตุ: วัดใน headless ซึ่งเป็น `dpr=1` — กลไกยืนยันแล้ว แต่ผลเรื่องเสียงพัดลมจริงต้องลองบนเครื่อง retina + ProMotion

## ที่ยังทำได้อีก (ไม่รวมใน PR นี้ เพราะมีผลต่อภาพ)

- `PRESETS.high.pixelRatio` 2 → 1.5 (ตัด fragment ~44% แต่ภาพนุ่มลง — ต้องมี screenshot จริง)
- shadow map 2048² → 1024²

🤖 Generated with [Claude Code](https://claude.com/claude-code)
