### PR TITLE
ci: ผูก deploy job กับ GitHub Environment ให้เห็นประวัติ deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,11 @@ jobs:
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # ทำให้ GitHub รู้จักการ deploy นี้ → ขึ้นกล่อง Environments ในแถบข้างหน้า repo
+    # และมีหน้า Deployments ไล่ประวัติได้ (secret ยังอยู่ระดับ repo ตามเดิม)
+    environment:
+      name: production-web
+      url: https://siahra-radar.co
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -64,6 +69,9 @@ jobs:
     if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment:
+      name: production-api
+      url: https://siahra-radar.co/api/v1/health
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7


### PR DESCRIPTION
## ทำไม

`deploy.yml` รัน `wrangler deploy` ตรง ๆ GitHub จึงไม่เคยรู้ว่ามีการ deploy — หน้า repo ไม่มีกล่อง **Environments** ในแถบข้าง และไม่มีหน้า Deployments ให้ไล่ดูว่า commit ไหนขึ้น production ไปแล้ว

## แก้อะไร

เพิ่ม `environment:` ให้สอง job:

| job | environment | url |
|---|---|---|
| `deploy-web` | `production-web` | https://siahra-radar.co |
| `deploy-api` | `production-api` | https://siahra-radar.co/api/v1/health |

GitHub จะสร้าง Environment ทั้งสองให้อัตโนมัติเมื่อ workflow รันครั้งแรก ไม่ต้องตั้งค่าอะไรก่อน และไม่มี protection rule (จะไม่บล็อก deploy) — secret `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` ยังอยู่ระดับ repo ใช้ได้ตามเดิม

## บริบท

เจอตอนไล่ว่าทำไม PR #16 merge แล้วไม่ deploy — สาเหตุจริงคือ secret `CLOUDFLARE_API_TOKEN` ถูกตั้งเป็นค่าว่าง (แก้แล้ว, deploy ผ่านแล้ว) ส่วน PR นี้แก้เรื่องที่ทำให้ *มองไม่เห็น* ว่า deploy เกิดขึ้นหรือไม่

ไม่แตะโค้ดที่มีผลทางตา → `no-screenshot`