### PR TITLE
ui: keep terrain relief at full strength when zoomed in

### DIFF
--- a/apps/web/src/scene/terrainMaterial.ts
+++ b/apps/web/src/scene/terrainMaterial.ts
@@ -22,7 +22,11 @@ export interface TerrainSharedUniforms {
   uOutsideDim: { value: number };
   uHillshade: { value: THREE.Texture | null };
   uHasHillshade: { value: number };
-  /** 1 at province scale -> ~0.4 close up; the lowland wash is a regional cue. */
+  /**
+   * 1 at province scale -> ~0.4 close up; the lowland wash is a regional cue
+   * and a full-strength one fills the screen with blue once a single district
+   * fills the frame. Relief (the hillshade) is deliberately outside this.
+   */
   uDetailFade: { value: number };
   /** 1 when the observation source is stale/unreachable: halos desaturate. */
   uHazardStale: { value: number };
@@ -125,10 +129,13 @@ vec4 ov = texture2D(uOverlay, vTerrainUv);
 float inside = ov.b;
 
 // Analytic hillshade from the DEM adds crisp relief on top of the scene
-// lighting (flat ground ~0.71 in gdaldem's output => neutral).
+// lighting (flat ground ~0.71 in gdaldem's output => neutral). Deliberately
+// NOT scaled by uDetailFade: relief is what makes the surface read as 3D at
+// every scale, and dimming it close up flattened the terrain just as the
+// slopes became worth looking at.
 if (uHasHillshade > 0.5) {
   float hs = texture2D(uHillshade, vTerrainUv).r;
-  diffuseColor.rgb *= mix(1.0, clamp(hs / 0.71, 0.35, 1.45), 0.6 * uDetailFade);
+  diffuseColor.rgb *= mix(1.0, clamp(hs / 0.71, 0.35, 1.45), 0.6);
 }
 
 // Neighbouring provinces: darker and slightly desaturated so the selected


### PR DESCRIPTION
## Problem

Zooming in flattens the terrain: the relief that models the hills at province scale washes out as soon as a few districts fill the frame.

`uDetailFade` (`Map3DCanvas.tsx`) ramps 1 -> 0.4 with camera distance and divides **two unrelated effects** in `terrainMaterial.ts`:

- the DEM hillshade — `mix(1.0, hs / 0.71, 0.6 * uDetailFade)`
- the illustrative lowland wash — `low = ov.r * uShowLowland * uDetailFade`

Fading the **wash** close up is deliberate and stays: at district scale a full-strength wash covers the screen in blue and competes with the observed GISTDA flood layer. Fading the **relief** with it is not — it flattens the terrain exactly when the slopes become worth looking at.

## Change

Take the hillshade out of the ramp (constant `0.6` mix). The wash keeps its existing distance behaviour, unchanged.

## Screenshots (Pattani, identical camera per pair)

**Before — 60 km, relief at 0.53: hills on the right read flat**
![before-60km](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-map-fix-cosmetic/b-zoom-faded.png)

**After — 60 km, relief at full strength; the plain is not blue-washed (wash still at 0.53, unchanged)**
![after-60km](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-map-fix-cosmetic/w2-60km-fixed.png)

**After — 11 km over the hills: relief stays crisp, no blur artefacts from the 224 m/px hillshade texture**
![after-hills-close](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-map-fix-cosmetic/w3-hills-close.png)

**After — 35 km over the coastal plain: the lowland wash still steps back as before, so no blue sheet over the town**
![after-coast](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-map-fix-cosmetic/w1-coast-fixed.png)

## Verified

- `npx tsc -b` and `npx oxlint src` in apps/web pass
- `uDetailFade` read straight from `renderer.properties` at each framing to confirm the wash behaviour is untouched (0.40 at 35 km, 0.53 at 60 km — same as main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
