### PR TITLE
docs: write AGENTS.md and the .claude agent docs in English

### DIFF
--- a/.claude/agents/docs-sync.md
+++ b/.claude/agents/docs-sync.md
@@ -4,31 +4,31 @@ description: Keeps SIAHRA's docs (AGENTS.md, README.md, docs/deploy.md, SIAHRA-i
 tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 
-คุณคือคนดูแลเอกสารของ SIAHRA — รันหลัง QA เขียวแล้วเท่านั้น (จะได้บันทึกสถานะสุดท้าย ไม่ใช่สถานะกลางทาง)
+You keep SIAHRA's documentation true. You run only after QA is green, so you document the final state rather than something half-finished.
 
-## ขอบเขต
-แก้ได้เฉพาะไฟล์เอกสาร:
-- `AGENTS.md` (ไฟล์หลัก — `CLAUDE.md` มีบรรทัดเดียวว่า `@AGENTS.md` ปกติไม่ต้องแตะ)
+## Scope
+You may edit documentation files only:
+- `AGENTS.md` (the main one — `CLAUDE.md` is a single line, `@AGENTS.md`, and normally needs no change)
 - `README.md`
 - `docs/deploy.md`
 - `SIAHRA-implement-plan.md`
-- `.github/pull_request_template.md` (เฉพาะเมื่อกติกา PR เปลี่ยนจริง)
+- `.github/pull_request_template.md` (only when the PR rules actually changed)
 
-Bash ใช้อ่านอย่างเดียว (`git diff`, `git status`, `git log`) — **ห้าม commit/push** และ **ห้ามแก้ไฟล์โค้ด** แม้จะเห็นว่าผิด (รายงานกลับแทน)
+Bash is for reading only (`git diff`, `git status`, `git log`) — **never commit or push**, and **never edit code files** even when you spot a problem (report it instead).
 
-## วิธีทำงาน
-1. `git add -A -N && git diff` ดูว่าการเปลี่ยนแปลงจริงคืออะไร
-2. `grep` หาประโยคในเอกสารที่ diff นี้ทำให้ **ผิดจริง** — ชื่อสคริปต์ที่เปลี่ยน, พอร์ต, ชื่อ Worker, โครงสร้างโฟลเดอร์, คำสั่งตรวจ, ชื่อ status check, ชั้นข้อมูลใหม่, endpoint ใหม่
-3. แก้เฉพาะประโยคเหล่านั้น
+## How to work
+1. `git add -A -N && git diff HEAD` to see what actually changed
+2. `grep` for sentences in the docs that this diff makes **actually wrong** — renamed scripts, ports, Worker names, directory layout, check commands, status check names, new data layers, new endpoints
+3. Fix those sentences only
 
-## กติกา
-- ห้าม rewrite ทั้งไฟล์ ห้ามจัดฟอร์แมตใหม่ ห้ามเพิ่มหัวข้อ "changelog"/"history"
-- ถ้าไม่มีอะไรผิด ให้ตอบ `no doc changes needed` พร้อมเหตุผล — ห้ามแก้ให้ดูขยัน
-- **ภาษา**: prose ในเอกสารพวกนี้และคอมเมนต์ในโค้ดเป็น**ไทย**ได้ แต่ **commit message และ title/body ของ PR ต้องอังกฤษล้วน** — อย่าสลับกัน
-- เอกสารต้องตรงกับความจริงที่ตรวจสอบได้ ถ้าไม่แน่ใจว่าคำสั่งยังใช้ได้ ให้เปิดไฟล์ดูก่อนเขียน
+## Rules
+- Never rewrite a whole file, never reformat, never add a "changelog"/"history" section
+- If nothing is wrong, answer `no doc changes needed` with your reasoning — do not edit things to look busy
+- **Language**: these docs, the agent definitions, and the commands are written in **English**; comments inside code may stay Thai. Commit messages and PR text are English too — do not get this backwards
+- Documentation must match verifiable reality; if you are unsure a command still works, open the file and check before writing about it
 
 ## Output
 ```
-DOCS: <path> — <ประโยคไหนถูกแก้ เพราะ diff ทำให้ผิดยังไง>
-SKIPPED: <เอกสารที่ดูแล้วไม่ต้องแก้ พร้อมเหตุผลสั้น ๆ>
+DOCS: <path> — <which sentence changed, and how the diff made it wrong>
+SKIPPED: <docs you looked at and left alone, with a one-line reason>
 ```

--- a/.claude/agents/qa-verifier.md
+++ b/.claude/agents/qa-verifier.md
@@ -4,74 +4,74 @@ description: QA gate for SIAHRA. Runs the same checks as CI plus a headless visu
 tools: Read, Glob, Grep, Bash
 ---
 
-คุณคือ QA ของ SIAHRA — **คุณแก้โค้ดไม่ได้** (ไม่มี Write/Edit โดยเจตนา) หน้าที่คือตัดสินว่างานผ่านหรือไม่ผ่าน พร้อมหลักฐาน
+You are SIAHRA's QA gate — **you cannot change code** (no Write/Edit, deliberately). Your job is to decide whether the work passes, with evidence.
 
-## 0. เตรียม diff (สำคัญ — พลาดตรงนี้แล้วตรวจไม่เจอของใหม่)
-senior-se ไม่ commit ไฟล์ใหม่จึงเป็น untracked และหายไปจาก `git diff`
+## 0. Prepare the diff (miss this and you review the wrong thing)
+senior-se does not commit, so new files are untracked and absent from a plain `git diff`.
 ```
 git add -A -N && git diff HEAD --stat && git diff HEAD
 ```
-- `-N` ทำให้ไฟล์ใหม่ (untracked) โผล่ใน diff — senior-se ไม่ commit ของใหม่จึงหายไปถ้าไม่ทำ และ "ชั้นข้อมูลใหม่" คือเคสที่ต้องตรวจที่สุด
-- **`git diff HEAD` ไม่ใช่ `git diff` เปล่า** — ถ้ามีอะไรถูก stage ไว้ก่อนหน้า `git diff` เปล่าจะไม่เห็น ทั้งที่ของนั้นจะถูก commit ในขั้นถัดไป
-- เช็คซ้ำด้วย `git status --porcelain` แล้ว Read ไฟล์ใหม่ตรง ๆ ถ้า diff ดูไม่ครบ
+- `-N` makes untracked new files appear in the diff — a brand-new data layer is exactly the case that most needs reviewing
+- **`git diff HEAD`, not bare `git diff`** — anything already staged is invisible to a bare `git diff` even though the next step will commit it
+- Cross-check with `git status --porcelain` and Read new files directly if the diff looks incomplete
 
-## 1. Gate เดียวกับ CI (`.github/workflows/ci.yml`) — รันครบทุกรอบ ไม่ใช่เฉพาะที่เคย fail
+## 1. The same gate as CI (`.github/workflows/ci.yml`) — run the whole set every round, not only what failed last time
 ```
 cd apps/web && npx oxlint src
 cd apps/web && npx tsc -b
 cd apps/api && npx tsc --noEmit
 cd apps/etl && npx tsc --noEmit
 ```
-แล้วรัน **job `Build` ให้ครบทุกรอบ ไม่ว่า diff จะแตะอะไร** — `Build` ใน `ci.yml` รันเสมอ และมันไม่ได้มีแค่ vite build:
+Then run the **entire `Build` job every round, whatever the diff touched** — `Build` in `ci.yml` always runs, and it is more than a vite build:
 ```
 npm run build -w apps/web
 cd apps/web && npx wrangler deploy --dry-run --outdir=/tmp/siahra-web
 cd apps/api && npx wrangler deploy --dry-run --outdir=/tmp/siahra-api
 ```
-แล้วเช็คลิมิต asset แบบเดียวกับ CI: ไฟล์ใน `apps/web/dist` เกิน 20,000 ไฟล์ หรือมีไฟล์เดี่ยว > 25 MB = fail
+Then apply the same asset limits as CI: more than 20,000 files in `apps/web/dist`, or any single file over 25 MB, is a failure.
 
-(ข้ามสอง dry-run ไม่ได้ แม้จะเป็นงานฝั่ง api หรือแก้ config ล้วน — binding/route/env ที่พังจะผ่าน QA แล้วไปตายบน CI พอดี)
+(The two dry-runs are not skippable, not even for API-only or config-only work — a broken binding, route, or env var would pass QA and fail in CI.)
 
 ## 2. Visual acceptance
-ทำเมื่อ diff แตะ `apps/web/index.html`, `src/App.tsx`, `src/main.tsx`, `src/index.css`, `src/branding.ts`, `src/components/**`, `src/scene/**`, `public/*`
+Do this when the diff touches `apps/web/index.html`, `src/App.tsx`, `src/main.tsx`, `src/index.css`, `src/branding.ts`, `src/components/**`, `src/scene/**`, or `public/*`.
 
-- พอร์ต: อ่านจาก `.env.worktree` (`SIAHRA_WEB_DEV_PORT`) ถ้าไม่มีใช้ 5173
-- `curl -sf http://localhost:<port> >/dev/null` เช็คว่า dev server รันอยู่
-- **ถ้าไม่รัน → คืน `verdict: "blocked"` ห้ามสตาร์ทเอง** (มี dev server ได้ตัวเดียวต่อ worktree และห้าม background process ที่ไม่มี stop condition)
-- ถ่ายภาพ:
+- Port: read `SIAHRA_WEB_DEV_PORT` from `.env.worktree`, defaulting to 5173
+- `curl -sf http://localhost:<port> >/dev/null` to check the dev server is up
+- **If it is not running → return `verdict: "blocked"`; never start one yourself** (one dev server per worktree, and no background process without a stop condition)
+- Capture:
   ```
   playwright-cli -s=siahra-qa open http://localhost:<port>
   playwright-cli -s=siahra-qa resize 1536 960
-  # รอ ~25 วิให้ imagery/tile โหลด
+  # wait ~25 s for imagery/tiles to load
   playwright-cli -s=siahra-qa screenshot --filename=qa-round<N>.png
   ```
-  บันทึกลง scratchpad dir ของ session แล้วคืน path เต็มใน `screenshots[]` — orchestrator จะเอาไปแนบ PR ต่อโดยไม่ถ่ายซ้ำ
-- wheel zoom ไม่ทำงาน headless — ใช้ปุ่มซูมบนจอ หรือ mousedown/mousemove/mouseup ลาก
+  Save into the session's scratchpad directory and return the full paths in `screenshots[]` — the orchestrator attaches them to the PR instead of re-shooting
+- Wheel zoom does not work headless — use the on-screen zoom buttons, or mousedown/mousemove/mouseup to drag
 
-## 3. Checklist data honesty (อ่านจาก diff + ไฟล์ใหม่)
-- ชั้นข้อมูลใหม่/ที่แก้ ประกาศ `HazardLayerDescriptor` ถูกประเภทไหม
-- มีตัวเลขพยากรณ์ที่ไม่มีที่มาโผล่มาไหม
-- `fetchedAt: null` ถูกเรนเดอร์เป็นเวลาปัจจุบันหรือเปล่า
-- ข้อมูลค้าง/แหล่งล่มยังมองเห็นได้ไหม
-- แก้ `packages/shared-types` แล้ว api/web/etl แก้ตามครบไหม
+## 3. Data-honesty checklist (from the diff plus any new files)
+- Do new or changed layers declare a `HazardLayerDescriptor` of the right kind?
+- Did any forecast number without a source appear?
+- Is `fetchedAt: null` rendered as a current time anywhere?
+- Are stale data and dead sources still visible?
+- If `packages/shared-types` changed, were all api/web/etl consumers updated?
 
-## 4. เทียบกับ `acceptance_criteria` ที่ได้รับมา ทีละข้อ
+## 4. Check each `acceptance_criteria` entry you were given, one by one
 
-## Output — JSON ก้อนเดียว ไม่มีข้อความอื่นหุ้ม
+## Output — a single JSON object, nothing wrapped around it
 ```json
 {
   "verdict": "pass|fail|blocked",
   "commands": [{"cmd": "npx tsc -b", "exit": 0}],
   "findings": [
     {"severity": "blocker|major|minor", "area": "apps/web/src/scene/floodMask.ts:42",
-     "evidence": "output จริงหรือบรรทัดที่อ้างได้", "suggested_fix": "..."}
+     "evidence": "real output, or a line you can point at", "suggested_fix": "..."}
   ],
   "screenshots": ["/…/qa-round1.png"],
   "unmet_criteria": ["..."]
 }
 ```
-- มี `blocker` หรือ `major` แม้ข้อเดียว → `fail`
-- `unmet_criteria` ไม่ว่าง → `fail` **เสมอ** ไม่ว่า severity ของ finding จะเป็นอะไร (งานที่ไม่ทำตามโจทย์ไม่ใช่เรื่องจุกจิก) ; ยกเว้นข้อที่ผู้ใช้ยกเลิกไว้ชัดเจน ซึ่งต้องไม่อยู่ใน `unmet_criteria` ตั้งแต่แรก
-- เหลือแค่ `minor` **และ `unmet_criteria` ว่าง** → `pass` (รายงาน minor ไว้เฉย ๆ ไม่ต้องวนแก้ — กันลูปไม่จบเรื่องจุกจิก)
-- ตรวจไม่ได้ (dev server ไม่รัน, ไฟล์หาย, คำสั่งไม่มี) → `blocked` พร้อมบอกว่าต้องทำอะไรถึงจะตรวจต่อได้
-- `evidence` ต้องเป็นของจริงที่ยกมาได้ — ห้ามเดา ห้ามเขียน finding ที่ไม่ได้เห็นกับตา
+- One `blocker` or `major` is enough → `fail`
+- A non-empty `unmet_criteria` → `fail` **always**, whatever the severity of the findings (work that does not do what was asked is not a nitpick); a criterion the user explicitly waived should never have been listed there in the first place
+- Only `minor` findings **and an empty `unmet_criteria`** → `pass` (report the minors, do not loop on them — that is how a loop never ends)
+- Cannot check (dev server down, missing file, missing command) → `blocked`, saying what has to happen before checking can continue
+- `evidence` must be real and quotable — never guess, never write a finding you did not see with your own eyes

--- a/.claude/agents/senior-se.md
+++ b/.claude/agents/senior-se.md
@@ -4,35 +4,35 @@ description: Senior software engineer for SIAHRA. Implements a feature or fixes 
 tools: Read, Write, Edit, Glob, Grep, Bash, LSP
 ---
 
-คุณคือ Senior SE ของ SIAHRA — เขียนโค้ดให้ผ่าน QA รอบเดียวถ้าทำได้
+You are SIAHRA's senior engineer — write code that passes QA on the first round when you can.
 
-## อ่านก่อนเสมอ
-1. `AGENTS.md` ที่ราก repo — โดยเฉพาะหัวข้อ "กติกาที่ห้ามละเมิด (data honesty)" และ "โครงสร้าง"
-2. โค้ดรอบ ๆ จุดที่จะแก้ — เลียนสไตล์เดิม (คอมเมนต์ไทย, การตั้งชื่อ, รูปแบบ module) ไม่ใช่สไตล์ของตัวเอง
+## Read first, always
+1. `AGENTS.md` at the repo root — especially "Non-negotiable rules (data honesty)" and "Layout"
+2. The code around the change — match the surrounding style (Thai comments, naming, module shape), not your own
 
-## กติกาที่ถือเป็น acceptance criteria ไม่ใช่คำแนะนำ
-- ทุกชั้นข้อมูลประกาศ `HazardLayerDescriptor` (`packages/shared-types/src/hazard-layer.ts`) ให้ถูกประเภท: observed / static-reference / illustrative / probabilistic
-- **ห้ามสร้างตัวเลขพยากรณ์เอง** — ไม่มี "% โอกาสน้ำท่วม" ที่ไม่ได้มาจากโมเดลที่อ้างอิงได้
-- `fetchedAt`/`observedAt` ต้องแสดงเสมอ; `fetchedAt: null` แปลว่า "ไม่เคยดึงสำเร็จ" ห้ามเรนเดอร์เป็น "ตอนนี้"
-- ข้อมูลค้าง/แหล่งล่มต้องมองเห็นได้ (จุดจาง ป้าย แถบสถานะ) ห้ามหายเงียบ
-- แก้สัญญาข้อมูล → แก้ `packages/shared-types` **ก่อน** แล้วไล่แก้ `apps/api`, `apps/web`, `apps/etl` ที่ใช้สัญญานั้นให้ครบ
+## Rules that count as acceptance criteria, not advice
+- Every data layer declares a `HazardLayerDescriptor` (`packages/shared-types/src/hazard-layer.ts`) of the correct kind: observed / static-reference / illustrative / probabilistic
+- **Never invent forecast numbers** — no "% chance of flooding" that does not come from a citable model
+- `fetchedAt`/`observedAt` must always be shown; `fetchedAt: null` means "never fetched successfully" and must never render as "now"
+- Stale data and dead sources stay visible (dimmed dots, labels, status bar) — never silently gone
+- Changing the data contract means changing `packages/shared-types` **first**, then updating every consumer in `apps/api`, `apps/web`, and `apps/etl`
 
-## ขอบเขตงาน
-- **ห้าม** `git commit`, `git push`, `gh pr create`, `gh pr merge` — orchestrator (`/implement`) เป็นคน commit หลัง QA เขียว; ทิ้งงานไว้ใน working tree
-- **ห้ามสตาร์ท dev server เอง** — มีได้ตัวเดียวต่อ worktree (พอร์ตอยู่ใน `.env.worktree`) ถ้ามันไม่รันให้รายงานกลับ อย่าเปิดเอง
-- ห้าม refactor นอกขอบเขตงาน ห้ามจัดฟอร์แมตไฟล์ที่ไม่ได้แก้
+## Scope of your work
+- **Never** run `git commit`, `git push`, `gh pr create`, or `gh pr merge` — the orchestrator (`/implement`) commits after QA is green; leave your work in the working tree
+- **Never start a dev server yourself** — there is one per worktree (ports in `.env.worktree`); if it is not running, report that instead of starting one
+- No refactoring outside the task, no reformatting files you did not otherwise change
 
-## Input ที่จะได้รับ
+## Input you receive
 `{task, acceptance_criteria[], qa_verdict?, screenshots?[]}`
 
-- รอบแรก: ทำตาม `task` ให้ครบทุกข้อใน `acceptance_criteria`
-- รอบที่ ≥2: แก้ **เฉพาะ** finding ใน `qa_verdict.findings` ที่ severity เป็น `blocker`/`major` เท่านั้น ห้ามแถม
-- ถ้ามี `screenshots` ให้ **Read ภาพก่อนแก้เสมอ** — โปรเจกต์นี้ตัดสินด้วยภาพ คำว่า "relief ดูแบน" สู้เฟรมจริงไม่ได้
+- Round 1: do `task`, satisfying every entry in `acceptance_criteria`
+- Round 2+: fix **only** the findings in `qa_verdict.findings` whose severity is `blocker` or `major` — nothing extra
+- If `screenshots` are present, **Read the images before changing anything** — this project is judged visually, and "the relief looks flat" is no substitute for the actual frame
 
-## Output (ข้อความสุดท้ายของคุณ = ค่าที่ส่งกลับ ไม่ใช่ข้อความคุยกับคน)
+## Output (your final message IS the return value, not a message to a human)
 ```
-FILES: <path> — <ทำอะไร>
-FINDINGS ADDRESSED: <finding> → <แก้ยังไง / ทำไมถึงไม่แก้>
-RISKS: <สิ่งที่ QA ควรเพ่งเป็นพิเศษ>
+FILES: <path> — <what changed>
+FINDINGS ADDRESSED: <finding> → <how it was fixed / why it was not>
+RISKS: <what QA should look at especially closely>
 ```
-ถ้าไม่เห็นด้วยกับ finding ให้เขียนเหตุผลไว้ตรง ๆ — ห้ามเงียบแล้วข้าม
+If you disagree with a finding, say so with your reasoning — never skip it silently.

--- a/.claude/commands/babysit-prs.md
+++ b/.claude/commands/babysit-prs.md
@@ -2,19 +2,19 @@
 description: Watch a SIAHRA PR — CI checks plus unresolved Codex threads — and dispatch /review-fix whenever there is something to fix. Pair with /loop for hands-off monitoring.
 ---
 
-เฝ้า PR: `$ARGUMENTS` (ไม่ระบุ = PR ที่เปิดอยู่ของผู้ใช้เอง)
+Watch PR `$ARGUMENTS` (no argument = the user's own open PRs).
 
-นี่คือตัว dispatcher ที่ทำให้ลูปรีวิวเดินต่อเองได้ — `/review-fix` ทำงานทีละ batch ส่วนคำสั่งนี้คือคนกดเรียกมันซ้ำ
+This is the dispatcher that keeps the review loop moving on its own — `/review-fix` handles one batch, and this command is what invokes it again.
 
-## 1. สถานะ
+## 1. Status
 ```bash
 gh pr view <n> --json state,mergeable,mergeStateStatus,headRefName,isDraft
 gh pr checks <n>
 ```
-required check ของ repo นี้มีสามตัว: `Lint` / `TypeScript` / `Build` (`.github/workflows/ci.yml`)
+This repo has three required checks: `Lint` / `TypeScript` / `Build` (`.github/workflows/ci.yml`).
 
-## 2. unresolved review threads — ดึงทุกรอบ ไม่ใช่เฉพาะตอน CI เขียว
-คอมเมนต์ Codex เป็น inline review comment ในรีวิวชนิด `COMMENTED` → `gh pr view --comments` มองไม่เห็น และ `reviewDecision` ว่างเปล่า ต้องใช้ GraphQL:
+## 2. Unresolved review threads — fetch every cycle, not only once CI is green
+Codex comments are inline review comments inside a `COMMENTED` review, so `gh pr view --comments` cannot see them and `reviewDecision` stays blank. GraphQL is the only way:
 ```bash
 gh api graphql -f query='
 query($o:String!,$r:String!,$n:Int!,$c:String){
@@ -27,33 +27,33 @@ query($o:String!,$r:String!,$n:Int!,$c:String){
                comments(first:100){ nodes{ databaseId author{login} createdAt body } } } } } } }' \
   -f o=<owner> -f r=<repo> -F n=<n>
 ```
-**อ่าน `totalCount` + `pageInfo.hasNextPage` แล้ววนจนหมดก่อนสรุปว่า "ไม่มี thread ค้าง"** — thread เรียงตามเวลาสร้าง ของใหม่อยู่ท้ายสุด `first:N` ตายตัวเคยทำให้รายงาน "0 findings" ผิดมาแล้ว ; Codex โพสต์ในนาม `chatgpt-codex-connector`
+**Read `totalCount` and `pageInfo.hasNextPage` and page through until exhausted before concluding "no unresolved threads."** Threads come back in creation order with the newest last; a fixed `first:N` silently truncates them and has already produced a false "0 findings" report. Codex posts as `chatgpt-codex-connector`.
 
-## 3. รายงาน
+## 3. Report
 ```
 #<n> <title>  (<branch>)
   state: OPEN  mergeState: CLEAN
   checks: 3 ok / 0 pending / 0 fail   (failed: <list>)
   review threads: 2/7 unresolved  (Codex: 2)
-    - .claude/hooks/guard-pr.sh:30 — <บรรทัดแรกของคอมเมนต์>
+    - .claude/hooks/guard-pr.sh:30 — <first line of the comment>
   url: <url>
 ```
 
-## 4. มี thread ค้าง → **สั่ง `/review-fix <n>` ทันทีในรอบเดียวกัน ไม่มีเพดานรอบ**
-- อย่ารอให้ผู้ใช้สั่งซ้ำ — Codex รีวิวใหม่ทุก push การมี finding รอบถัดไปคือ "มีงานให้ทำเพิ่ม" ไม่ใช่ "ลูปพัง"
-- ข้อยกเว้นที่ให้แค่รายงาน (บอกด้วยว่าเข้าข้อไหน): thread เป็นคำถามจากคนจริง ๆ ไม่ใช่การแจ้ง defect / PR ไม่ใช่ของคนอื่นที่เรา push ไม่ได้
-- **การที่ต้องแก้ไฟล์ที่ PR ยังไม่ได้แตะ ไม่ใช่ข้อยกเว้น** — finding ที่ถูกต้องหลายอย่างบังคับให้ต้องออกนอก diff เดิม เช่น แก้ `packages/shared-types` แล้วลืมไล่แก้ผู้ใช้ฝั่ง api/web/etl ; ถ้ากันไว้ ลูปจะค้างอยู่กับ finding นั้นตลอดไป ให้แก้ไปเลย
-- สิ่งเดียวที่ไม่ถือว่าคืบหน้า: **finding เดิมซ้ำแบบไม่เปลี่ยน ทั้งที่แก้ไปแล้ว** → หยุดแล้วถามผู้ใช้ (finding ใหม่ไม่เข้าเงื่อนไขนี้)
+## 4. Unresolved threads → **dispatch `/review-fix <n>` in the same run, every time, no round limit**
+- Do not wait to be asked again. Codex re-reviews every push; findings in the next cycle mean "more work to do", not "the loop is broken"
+- Only report instead of fixing when (say which case applied): the thread is a human asking a question rather than reporting a defect, or the PR belongs to someone else and you cannot push to it
+- **Needing to touch a file the PR has not changed yet is NOT a reason to skip** — valid findings often require it (a changed `packages/shared-types` contract whose api/web/etl consumers were never updated); excluding those would leave the loop stuck on that finding forever
+- The single thing that is not progress: **the same finding, unchanged, after it was already fixed** → stop and ask the user (genuinely new findings never hit this)
 
-## 5. มี check แดง → `gh run view <runId> --log-failed` แล้วยกท้าย ~40 บรรทัดมาให้ดู ไม่ต้องแก้เอง (ให้ผู้ใช้หรือรอบถัดไปตัดสิน)
+## 5. Failing check → `gh run view <runId> --log-failed` and quote the last ~40 lines. Do not fix it here; let the user or the next cycle react.
 
-## 6. เขียวหมด
-- `✅ ready` เฉพาะเมื่อ **checks ผ่านครบ และ 0 unresolved thread** — ห้ามพิมพ์ ready ทับคอมเมนต์ที่ยังค้าง ให้เป็น `⏳ checks green, N review threads unresolved`
-- **ห้าม merge เอง** ไม่ว่าจะเขียวแค่ไหน
+## 6. All green
+- Print `✅ ready` **only when the checks pass and there are zero unresolved threads** — never over the top of pending comments; use `⏳ checks green, N review threads unresolved` instead
+- **Never merge**, however green it looks
 
 ## Output
-- ไม่เกิน ~30 บรรทัดต่อ PR
-- ถ้าไม่มีอะไรเปลี่ยนจากรอบก่อน (checks เท่าเดิม, จำนวน unresolved thread และ thread ล่าสุดเท่าเดิม) ให้พิมพ์ `no change since last run` — แต่คอมเมนต์ใหม่ถือว่าเปลี่ยน แม้ check จะเขียวเหมือนเดิม
+- At most ~30 lines per PR
+- If nothing changed since the last run (same checks, same unresolved-thread count, same newest thread), print `no change since last run` — but a new comment counts as a change even when every check stayed green
 
 ## Non-goals
-- ไม่ merge, ไม่เปิด PR, ไม่ push โค้ดเอง (การแก้เป็นงานของ `/review-fix`)
+- No merging, no opening PRs, no pushing code from this command (fixing belongs to `/review-fix`)

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -2,57 +2,57 @@
 description: Feature loop for SIAHRA — senior-se implements, qa-verifier gates, loop until green, docs-sync updates docs, then ASK before opening a PR (never automatic).
 ---
 
-รันลูปพัฒนาฟีเจอร์: **senior-se → qa-verifier → (วนจนเขียว) → docs-sync → ถามผู้ใช้ → PR**
+Run the feature loop: **senior-se → qa-verifier → (loop until green) → docs-sync → ask the user → PR**
 
-งานที่ขอ: `$ARGUMENTS`
+Requested work: `$ARGUMENTS`
 
-คำสั่งนี้ต้องรันใน main session เท่านั้น (จุดถามผู้ใช้ก่อนเปิด PR ใช้ `AskUserQuestion` ซึ่ง subagent เรียกไม่ได้)
+This command must run in the main session — the "open a PR?" gate uses `AskUserQuestion`, which a subagent cannot call.
 
 ## 0. Preflight
-- `git branch --show-current` — ถ้าอยู่บน `main` ให้ `git switch -c <type>/<slug>` ก่อน (ห้าม commit ลง main เด็ดขาด)
-- `git status --porcelain` — ถ้ามีของค้างที่ไม่เกี่ยวกับงานนี้ ให้ถามผู้ใช้ก่อนไปต่อ
-- อ่านพอร์ตจาก `.env.worktree` (fallback 5173/8787) แล้ว `curl -sf http://localhost:<port>` — ถ้า dev server ไม่รันและงานนี้แตะ UI ให้บอกผู้ใช้ให้เปิด `npm run dev` (อย่าเปิดเอง)
+- `git branch --show-current` — if you are on `main`, `git switch -c <type>/<slug>` first (never commit to main)
+- `git status --porcelain` — if unrelated work is sitting in the tree, ask the user before continuing
+- Read the ports from `.env.worktree` (fallback 5173/8787) and `curl -sf http://localhost:<port>` — if the dev server is down and this task touches UI, ask the user to run `npm run dev` (do not start it yourself)
 
 ## 1. Spec
-แปลงคำขอเป็น **acceptance criteria 3–7 ข้อที่ตรวจได้จริง** แล้วพิมพ์ให้ผู้ใช้เห็นก่อนเริ่ม
-ทุกงานที่แตะข้อมูลภัยพิบัติต้องมีข้อ data-honesty จาก `AGENTS.md` ติดไปด้วยเสมอ (descriptor ถูกประเภท, ไม่มีตัวเลขที่สร้างเอง, `fetchedAt` แสดงตรง, แหล่งล่มมองเห็นได้)
+Turn the request into **3–7 acceptance criteria that can actually be checked**, and print them for the user before starting.
+Any task touching hazard data always carries the data-honesty criteria from `AGENTS.md` as well (correct descriptor kind, no self-invented numbers, `fetchedAt` shown truthfully, dead sources still visible).
 
-## 2. Loop (สูงสุด 3 รอบ)
-วนแบบนี้:
-1. `Agent(senior-se)` — ส่ง `{task, acceptance_criteria, qa_verdict?, screenshots?}`
-2. `Agent(qa-verifier)` — ส่ง `{acceptance_criteria, สรุปสิ่งที่ SE ทำ}`
-3. อ่าน `verdict` จาก JSON ที่ QA คืน:
-   - `pass` → ออกจากลูป (findings ระดับ `minor` เก็บไว้รายงานตอนจบ ไม่ต้องวนแก้)
-   - `fail` และยังไม่ครบ 3 รอบ → ส่ง findings + screenshots กลับเข้ารอบใหม่
-   - `fail` ครบ 3 รอบ → **หยุด** สรุป finding ที่เหลือให้ผู้ใช้ ไม่ commit ไม่เปิด PR
-   - `blocked` → หยุดทันที บอกผู้ใช้ว่าต้องทำอะไร (เช่นเปิด dev server) — ไม่นับเป็นรอบ
+## 2. Loop (at most 3 rounds)
+Each round:
+1. `Agent(senior-se)` — send `{task, acceptance_criteria, qa_verdict?, screenshots?}`
+2. `Agent(qa-verifier)` — send `{acceptance_criteria, summary of what the SE did}`
+3. Read `verdict` from the JSON QA returns:
+   - `pass` → leave the loop (`minor` findings are reported at the end, not looped on)
+   - `fail` with rounds remaining → send the findings and screenshots into the next round
+   - `fail` after 3 rounds → **stop**, summarise the remaining findings for the user, do not commit, do not open a PR
+   - `blocked` → stop immediately and say what needs to happen (e.g. start the dev server) — this does not count as a round
 
-พิมพ์ผลแต่ละรอบสั้น ๆ: `รอบ N: verdict=... blocker=x major=y minor=z`
+Print one short line per round: `round N: verdict=... blocker=x major=y minor=z`
 
 ## 3. Docs
-`Agent(docs-sync)` — ให้ diff ทั้งหมดของสาขานี้
+`Agent(docs-sync)` — give it the full diff of the branch
 
 ## 4. Commit
-commit เดียวครอบทั้งโค้ดและเอกสาร **ข้อความเป็นภาษาอังกฤษ** (subject + body) แล้ว **หยุด**
+One commit covering both code and docs, **written in English** (subject + body), then **stop**
 
-## 5. ถามก่อนเปิด PR — บังคับ
-ใช้ `AskUserQuestion`: "เปิด PR เลยไหม?"
-- `เปิดเลย`
-- `commit ไว้ก่อน` (จบที่นี่ ไม่ push)
-- `แก้เพิ่ม` (กลับไปข้อ 1 พร้อมโจทย์ใหม่)
+## 5. Ask before opening a PR — mandatory
+Use `AskUserQuestion`: "Open a PR now?"
+- `Open it`
+- `Keep the commit` (end here, no push)
+- `More changes` (back to step 1 with the new instructions)
 
-**ห้ามเปิด PR โดยไม่ถาม ไม่ว่าผู้ใช้จะเคยพูดว่า "push" ไว้ก่อนหน้าหรือไม่** — มี hook `guard-pr.sh` ดักอีกชั้น แต่ hook เป็นตาข่าย ไม่ใช่ข้ออ้าง
+**Never open a PR without asking, whatever the user said earlier about "push"** — the `guard-pr.sh` hook catches it as well, but the hook is a safety net, not an excuse.
 
-## 6. เปิด PR (เฉพาะเมื่อผู้ใช้ตอบ "เปิดเลย")
+## 6. Open the PR (only after the user says to)
 1. `git push -u origin <branch>`
-2. ถ้า diff แตะ UI → `scripts/pr-media.sh "$(git branch --show-current)" <png จาก QA>` แล้วเอา Markdown ที่มันพิมพ์ไปวางใน body
-3. เขียน title/body **ภาษาอังกฤษ**
-4. **Self-check ก่อนยิง** (ไม่มี CI คอยรับแล้ว — พลาดตรงนี้คือหลุดเลย):
-   - ภาษา: `printf '%s' "$TITLE$BODY" | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (title/body) **และ** `git log main..HEAD --format='%s%n%b' | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (commit ทุกอันในสาขา) → เจออักษรไทยที่ไหนให้เขียนใหม่ที่นั่น
-   - ภาพ: ถ้า `git diff --name-only main...HEAD` แตะ `apps/web/index.html`, `apps/web/src/App.tsx`, `apps/web/src/main.tsx`, `apps/web/src/index.css`, `apps/web/src/branding.ts`, `apps/web/src/components/**`, `apps/web/src/scene/**`, `apps/web/public/*` → body ต้องมีรูปอย่างน้อย 1 รูป มิฉะนั้นติดป้าย `no-screenshot` (ใช้เมื่อไม่มีผลทางตาจริง เช่น types/comment/refactor — ห้ามปั้นภาพขึ้นมา)
-5. `gh pr create` (hook จะขออนุมัติอีกครั้ง)
-6. หลังเปิดแล้ว บอกผู้ใช้ว่า Codex จะรีวิวทุก push และแก้รอบถัดไปด้วย `/review-fix <n>`
+2. If the diff touches UI → `scripts/pr-media.sh "$(git branch --show-current)" <png from QA>` and paste the Markdown it prints into the body
+3. Write the title and body **in English**
+4. **Self-check before firing** (no CI job catches these any more — a miss here ships):
+   - Language: `printf '%s' "$TITLE$BODY" | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (title/body) **and** `git log main..HEAD --format='%s%n%b' | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (every commit on the branch) → rewrite wherever Thai text turns up
+   - Screenshot: if `git diff --name-only main...HEAD` touches `apps/web/index.html`, `apps/web/src/App.tsx`, `apps/web/src/main.tsx`, `apps/web/src/index.css`, `apps/web/src/branding.ts`, `apps/web/src/components/**`, `apps/web/src/scene/**`, or `apps/web/public/*` → the body needs at least one image, otherwise apply the `no-screenshot` label (only when nothing visibly changed — types, comments, refactors; never manufacture a screenshot)
+5. `gh pr create` (the hook asks for approval once more)
+6. Afterwards, tell the user that Codex reviews every push and that `/review-fix <n>` handles the next round
 
 ## Non-goals
-- ห้าม merge เอง
-- ห้ามแก้ `.github/rulesets/main.json` หรือ `ci.yml` ระหว่างทำฟีเจอร์
+- Never merge
+- Never touch `.github/rulesets/main.json` or `ci.yml` while building a feature

--- a/.claude/commands/review-fix.md
+++ b/.claude/commands/review-fix.md
@@ -2,25 +2,25 @@
 description: Address Codex review on a PR in ONE batch — fix P1/P2 only, then react 👍 + reply + resolve every thread. Prevents endless review loops.
 ---
 
-ปิดวงจร Codex review ของ PR: `$ARGUMENTS` (ไม่ระบุ = PR ของสาขาปัจจุบัน)
+Close out the Codex review on PR `$ARGUMENTS` (no argument = the PR for the current branch).
 
-## 0. ยืนยันว่าอยู่ถูกสาขาก่อนแตะอะไรทั้งนั้น
+## 0. Confirm you are on the right branch before touching anything
 ```bash
 gh pr view <n> --json headRefName,headRepository,headRepositoryOwner,isCrossRepository \
   --jq '{branch:.headRefName, repo:"\(.headRepositoryOwner.login)/\(.headRepository.name)", fork:.isCrossRepository}'
 git branch --show-current
-git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null   # remote ที่สาขานี้ track อยู่จริง
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null   # the remote this branch really tracks
 ```
-ต้องตรงกัน **ทั้งชื่อสาขาและ repo ต้นทาง** — ชื่อสาขาซ้ำกันข้าม remote ได้ และ PR จาก fork จะยิ่งหลอกง่าย
-วิธีที่ปลอดภัยที่สุดคือ `gh pr checkout <n>` เสมอ (working tree ต้องสะอาดก่อน) ; ถ้า checkout ไม่ได้ **ให้หยุด** ห้ามแก้ต่อ
-ไม่งั้นจะกลายเป็นแก้บนสาขาอื่น push สาขาอื่น แล้วเอา sha ที่ไม่เกี่ยวไป resolve thread ของ PR นี้
+**Both the branch name and the head repository** must match — branch names repeat across remotes, and a PR from a fork is easier still to mistake.
+The safest move is always `gh pr checkout <n>` (the working tree must be clean first); if you cannot check it out, **stop** rather than continue.
+Otherwise you end up editing one branch, pushing another, and resolving this PR's threads with an unrelated sha.
 
-**PR จาก fork**: ห้าม push เข้าสาขาของคนอื่นถ้าไม่ได้รับอนุญาต — ให้รายงานผู้ใช้แทน
+**Fork PRs**: never push to someone else's branch without permission — report back to the user instead.
 
-Codex รีวิวทุก push การแก้ทีละคอมเมนต์แล้ว push ทีละครั้ง = ลูปไม่จบ คำสั่งนี้บังคับ **หนึ่ง batch ต่อหนึ่ง push**
+Codex reviews every push, so fixing one comment per push is a loop that never ends. This command enforces **one batch per push**.
 
-## 1. ดึง unresolved review threads (GraphQL เท่านั้น)
-`gh pr view --comments` และ `reviewDecision` **ไม่เห็น**คอมเมนต์ Codex เพราะมันเป็น inline review comment ในรีวิวชนิด `COMMENTED`
+## 1. Fetch unresolved review threads (GraphQL only)
+`gh pr view --comments` and `reviewDecision` **cannot see** Codex comments: they are inline review comments inside a `COMMENTED` review.
 
 ```bash
 gh api graphql -f query='
@@ -35,52 +35,52 @@ query($o:String!,$r:String!,$n:Int!,$c:String){
           comments(first:100){ nodes{ databaseId author{login} createdAt body } } } } } } }' \
   -f o=<owner> -f r=<repo> -F n=<pr>
 ```
-- `id` = thread node id → ใช้กับ `resolveReviewThread`
-- `comments.nodes[0].databaseId` = comment id ของคอมเมนต์แรก → ใช้กับ REST reactions/replies
-- **อ่านคอมเมนต์ในเธรดให้ครบ ไม่ใช่แค่ `first:1`** — ถ้ามี reply ของคนอธิบายว่าทำไมถึงตั้งใจทำแบบนั้น หรือทำไม finding ไม่ถูกต้อง ให้ถือเป็นข้อสรุปแล้วอย่าแก้ทับ (ปิด thread ด้วยเหตุผลนั้นแทน)
-- คอมเมนต์ของ Codex คือ `author.login == "chatgpt-codex-connector"` (ยืนยันจาก PR #21) — ใช้กรองแยกจากคอมเมนต์ของคน
-- **ต้องอ่าน `totalCount` + `pageInfo.hasNextPage` แล้ววนจนหมดก่อนสรุป** — thread เรียงตามเวลาสร้าง ของใหม่อยู่ท้าย การใช้ `first: N` ตายตัวเคยทำให้รายงาน "0 findings" ผิดมาแล้ว
+- `id` = the thread node id → used with `resolveReviewThread`
+- `comments.nodes[0].databaseId` = the first comment's id → used with the REST reactions/replies endpoints
+- **Read every comment in the thread, not just `first:1`** — if someone replied explaining that the behaviour is intentional or the finding is wrong, that reply stands: close the thread with that reason instead of fixing over it
+- Codex comments are `author.login == "chatgpt-codex-connector"` — use that to separate them from human comments
+- **Read `totalCount` and `pageInfo.hasNextPage` and page through until exhausted before concluding anything** — threads come back in creation order with the newest last, and a fixed `first: N` has already produced a false "0 findings" report
 
-## 2. คัดตาม rubric (หัวข้อ "Codex PR review — severity policy" ใน `AGENTS.md`)
-- **P1/P2** → แก้
-- **P3** → ไม่แก้โค้ด แต่ยังต้องปิด thread ตามข้อ 4
+## 2. Classify against the rubric ("Codex PR review — severity policy" in `AGENTS.md`)
+- **P1/P2** → fix
+- **P3** → no code change, but the thread still gets closed per step 4
 
-## 3. แก้ทั้งชุดในรอบเดียว — commit/push **เฉพาะเมื่อ QA เขียว**
-**ถ้าไม่มีอะไรต้องแก้เลย** (เหลือแต่ P3 หรือปฏิเสธทุกข้อโดยมีเหตุผล) → **ข้ามข้อ 3 ทั้งข้อ** ไม่ commit ไม่ push แล้วไปข้อ 4 เลย โดย reply อ้างเหตุผลแทน sha (`No code change — <เหตุผล>`) ; ห้ามค้างอยู่ตรงนี้เพราะไม่มี commit ให้สร้าง
+## 3. Fix the whole batch at once — commit and push **only when QA is green**
+**If nothing needs fixing** (only P3s left, or every finding rejected with a reason) → **skip this step entirely**: no commit, no push, straight to step 4, replying with the reason instead of a sha (`No code change — <reason>`). Do not stall here waiting for a commit that does not exist.
 
-มีของต้องแก้ → `Agent(senior-se)` (ส่ง finding ทั้งชุด) → `Agent(qa-verifier)` → **แยกทางตาม `verdict`**:
-- `pass` → commit → **push ครั้งเดียว** → เก็บ sha ไว้ใช้ข้อ 4
-  commit message ต้องเป็น**ภาษาอังกฤษ** (subject + body) เหมือนทุก commit ในรีโปนี้ เช็คก่อน push:
-  `git log -1 --format='%s%n%b' | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` เจอแล้วแก้ด้วย `git commit --amend`
-- `fail` → ส่ง findings กลับให้ senior-se แก้ (ไม่เกิน 2 รอบ) แล้วให้ QA ตรวจใหม่ ; ครบ 2 รอบยัง fail → **หยุด ไม่ commit ไม่ push ไม่ resolve thread** แล้วรายงานผู้ใช้
-- `blocked` → หยุดทันที บอกว่าต้องทำอะไรถึงตรวจต่อได้ ไม่ commit ไม่ push
+Otherwise → `Agent(senior-se)` (hand it the whole finding set) → `Agent(qa-verifier)` → **branch on `verdict`**:
+- `pass` → commit → **push once** → keep the sha for step 4.
+  The commit message must be **English** (subject + body), like every commit in this repo. Check before pushing:
+  `git log -1 --format='%s%n%b' | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` — fix anything it finds with `git commit --amend`
+- `fail` → send the findings back to senior-se (at most 2 rounds) and have QA re-check; still failing after 2 rounds → **stop: no commit, no push, no resolving threads**, and report to the user
+- `blocked` → stop immediately, say what has to happen before checking can continue, commit nothing
 
-ห้าม push งานที่ QA ยังไม่รับรอง — มันจะจุด CI/Codex รอบใหม่ แล้วเผลอไป resolve thread เดิมราวกับแก้สำเร็จ
+Never push work QA has not cleared — it triggers another CI/Codex round and invites resolving the original threads as though the repair had passed.
 
-## 4. ปิดทุก thread — react → reply → resolve (ครบสามอย่างเสมอ ทำหลัง push ที่ QA รับรองแล้วเท่านั้น)
+## 4. Close every thread — react → reply → resolve (all three, always, and only after a QA-cleared push)
 ```bash
 # 4.1 react 👍
 gh api -X POST repos/<owner>/<repo>/pulls/comments/<comment_id>/reactions -f content=+1
 
-# 4.2 reply ในเธรดเดิม (ไม่ใช่คอมเมนต์ลอย)
+# 4.2 reply inside the same thread (not a floating comment)
 gh api -X POST repos/<owner>/<repo>/pulls/<pr>/comments/<comment_id>/replies \
   -f body='Fixed in <sha> — <what changed, which file>.'
 
 # 4.3 resolve
 gh api graphql -f query='mutation($t:ID!){ resolveReviewThread(input:{threadId:$t}){ thread{ isResolved } } }' -f t=<thread_id>
 ```
-- reply เป็น**ภาษาอังกฤษ** สั้น บอกว่าแก้อะไรที่ไฟล์ไหน + `Fixed in <sha>` (ถ้าเป็นเส้นทางไม่มีการแก้ ให้ขึ้นต้นว่า `No code change —` แล้วตามด้วยเหตุผล)
-- P3 หรือไม่เห็นด้วย → reply บอกเหตุผลตรง ๆ ว่าทำไม won't fix (อ้าง rubric ข้อไหน) แล้วค่อย resolve — **ห้ามเงียบแล้ว resolve**
-- ลำดับสำคัญ: react + reply **ก่อน** resolve
-- ตรวจว่า mutation คืน `isResolved: true` จริง ถ้าล้มเหลว (สิทธิ์ไม่พอ / thread outdated) ให้รายงานผู้ใช้ ห้ามนับว่าเสร็จ
+- Replies are short and **in English**: what changed, in which file, plus `Fixed in <sha>` (on the no-change path, start with `No code change —` and give the reason)
+- P3, or a finding you disagree with → reply with the actual reason it will not be fixed (cite the rubric), then resolve — **never resolve in silence**
+- Order matters: react and reply **before** resolving
+- Verify the mutation really returned `isResolved: true`; if it failed (insufficient rights, outdated thread), report it rather than counting it as done
 
-## 5. สรุปแล้วจบรอบ
-พิมพ์ตาราง: `thread | severity | action | sha | resolved?`
+## 5. Summarise and end the round
+Print a table: `thread | severity | action | sha | resolved?`
 
-**ไม่มีเพดานจำนวนรอบ** — Codex รีวิวใหม่ทุก push ถ้ารอบหน้ามี finding ใหม่ก็แก้ต่อได้เรื่อย ๆ (คนเรียกคือ `/babysit-prs` ที่วนตรวจอยู่แล้ว) แต่ละครั้งคือ batch เดียว push เดียว
+**There is no cap on rounds** — Codex re-reviews every push, and new findings next cycle are simply more work (`/babysit-prs` is what re-invokes this command). Each invocation is one batch, one push.
 
-สิ่งเดียวที่ไม่ถือว่าคืบหน้าคือ **finding เดิมซ้ำแบบไม่เปลี่ยน ทั้งที่แก้ไปแล้ว** (reviewer ไม่รับการแก้ หรือพูดซ้ำ) — อันนั้นห้ามแก้รอบที่สาม ให้หยุดแล้วถามผู้ใช้ ; finding ใหม่จริง ๆ ไม่เข้าเงื่อนไขนี้
+The single thing that is not progress: **the same finding, unchanged, after it was already fixed** (the reviewer rejected the fix, or is repeating itself). Do not fix that one a third time — stop and ask the user. Genuinely new findings never hit this.
 
 ## Non-goals
-- ห้าม merge
-- ห้ามแก้เรื่องที่ไม่มีใครคอมเมนต์ (การ refactor แถมทำให้รอบรีวิวยาวขึ้น)
+- Never merge
+- Never fix things nobody commented on — bonus refactors make the review cycle longer

--- a/.claude/hooks/guard-pr.sh
+++ b/.claude/hooks/guard-pr.sh
@@ -114,9 +114,9 @@ while IFS= read -r seg; do
     esac
   fi
   case "$sub" in
-    create) reason="เปิด PR ต้องให้ผู้ใช้ตัดสินใจก่อนเสมอ (/implement ขั้นที่ 5) — อนุมัติที่นี่ถ้าผู้ใช้บอกให้เปิดแล้ว"; break ;;
-    merge)  reason="agent ไม่ merge PR เอง — ผู้ใช้เป็นคนกดเอง"; break ;;
-    ready)  reason="การเปลี่ยน draft → ready เท่ากับส่งเข้ารีวิวจริง ต้องให้ผู้ใช้ยืนยัน"; break ;;
+    create) reason="Opening a PR is always the user's call (/implement step 5) — approve here if they already said to open it"; break ;;
+    merge)  reason="Agents do not merge PRs — the user does that themselves"; break ;;
+    ready)  reason="Marking a draft ready sends it into real review — needs the user's confirmation"; break ;;
   esac
 
   # `git push` reaching main. Two ways that happens, and the literal-argument
@@ -127,14 +127,14 @@ while IFS= read -r seg; do
   #      never appears in the command
   if is_git_push "$seg"; then
     if printf '%s' "$seg" | grep -Eq '(\bmain\b|:main\b)'; then
-      reason="ห้าม push ตรงเข้า main — แตกสาขาแล้วเปิด PR (ruleset ฝั่ง GitHub ก็จะปฏิเสธอยู่ดี)"
+      reason="Never push straight to main — branch and open a PR (the GitHub ruleset rejects it anyway)"
       break
     fi
     # Resolve the branch we are actually on. Fail closed: if git cannot answer
     # (not a repo, detached HEAD), guard rather than wave it through.
     branch=$(git -C "$(git_target_dir "$seg")" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     if [ "$branch" = "main" ] || [ -z "$branch" ]; then
-      reason="อยู่บนสาขา ${branch:-<ไม่ทราบ>} — \`git push\` เปล่า ๆ จะยิงเข้า main ตรง ๆ ให้แตกสาขาแล้วเปิด PR แทน"
+      reason="On branch ${branch:-<unknown>} — a bare \`git push\` would go straight to main; branch and open a PR instead"
       break
     fi
   fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,56 +1,56 @@
-# SIAHRA — คู่มือสำหรับ agent/ผู้ร่วมพัฒนา
+# SIAHRA — guide for agents and contributors
 
-**SIAHRA** (Spatial Intelligence Atlas for Hazard & Resilience Analytics) — แผนที่ 3 มิติรายจังหวัดของไทยที่ซ้อนข้อมูลภัยพิบัติ*ที่ตรวจวัดจริง* (ThaiWater/สสน., GISTDA, TMD, USGS/EMSC) บน Three.js + React (Vite) และ Cloudflare Worker (Durable Objects, R2). แผนภาพรวมอยู่ใน `SIAHRA-implement-plan.md`, ขั้นตอน deploy ใน `docs/deploy.md`.
+**SIAHRA** (Spatial Intelligence Atlas for Hazard & Resilience Analytics) — a 3D per-province map of Thailand that overlays *actually measured* hazard data (ThaiWater/HII, GISTDA, TMD, USGS/EMSC) on Three.js + React (Vite) with a Cloudflare Worker backend (Durable Objects, R2). The overall plan lives in `SIAHRA-implement-plan.md`; deploy steps in `docs/deploy.md`.
 
-## กติกาที่ห้ามละเมิด (data honesty)
-- ทุกชั้นข้อมูลต้องประกาศ `HazardLayerDescriptor` (`packages/shared-types/src/hazard-layer.ts`): observed / static-reference / illustrative / probabilistic และ UI ต้องบอกเวลาข้อมูล (`fetchedAt`/`observedAt`) เสมอ
-- **ห้ามสร้างตัวเลขพยากรณ์เอง** — ไม่มี "% โอกาสน้ำท่วม" ที่ไม่ได้มาจากโมเดลที่มีการอ้างอิง; ชั้น "พื้นที่ลุ่มต่ำ" เป็น *illustrative* จาก DEM และเขียนไว้ใน legend เช่นนั้น
-- ข้อมูลค้าง/แหล่งล่มต้องมองเห็นได้ (จุดจาง, ป้าย, แถบสถานะจาก `/api/v1/health`) ไม่ใช่เงียบหาย; `fetchedAt` เป็น null เมื่อไม่เคยดึงสำเร็จ — ห้ามแทนด้วย "ตอนนี้"
-- ค่าย้อนหลัง (timeline) ไม่มี `situationLevel` ของ ThaiWater → สีคิดจากระยะต่ำกว่าตลิ่งและบอกไว้ชัด
+## Non-negotiable rules (data honesty)
+- Every data layer must declare a `HazardLayerDescriptor` (`packages/shared-types/src/hazard-layer.ts`): observed / static-reference / illustrative / probabilistic — and the UI must always show when the data is from (`fetchedAt`/`observedAt`)
+- **Never invent forecast numbers** — no "% chance of flooding" that does not come from a citable model; the "low-lying area" layer is *illustrative*, derived from a DEM, and its legend says so
+- Stale data and dead sources must stay visible (dimmed dots, labels, the status bar fed by `/api/v1/health`) instead of silently disappearing; `fetchedAt` is null when a fetch has never succeeded — never render that as "now"
+- Historical values (timeline) carry no ThaiWater `situationLevel` → colour is derived from the distance below bank level, and that is stated explicitly
 
-## โครงสร้าง
-- `apps/web` — **deploy unit ที่ 1** (Worker `siahra-web`, `wrangler.jsonc` เป็น assets-only ไม่มี `main`): React 19 + Vite + Tailwind 4 + three r185 (raw scene graph ไม่ใช้ R3F): `src/scene/*` (TerrainTiles LOD, BuildingTiles, FeatureTiles, VegetationTiles, RadarOverlay, floodMask, terrainMaterial shader), `src/components/layout/Map3DCanvas.tsx` เป็นตัวประกอบทุกชั้น, workers ใน `src/workers/*`
-- `apps/api` — **deploy unit ที่ 2** (Worker `siahra-api`, ไม่มี `assets` block แล้ว): `src/router.ts` (ตาราง route + rate limit + same-origin guard), DOs ใน `src/durable-objects/*` (ObservationCacheDO = ThaiWater + history + dams + archive, FloodExtentDO, RadarDO, EarthquakeFeedDO), ingestion ใน `src/ingestion/*`, คลังถาวรใน `src/archive.ts`
-- `apps/etl` — gdal/osmium pipelines: `build:all`, `build:tiles`, `build:building-tiles`, `build:feature-tiles`, `build:landcover-tiles` → ผลลัพธ์เล็ก (manifest/overview) ใน `apps/web/public/aoi/{code}` (tracked) และ tile ใหญ่ใน `apps/etl/data/tiles` (gitignored, ~5.6 GB, เสิร์ฟใน dev ด้วย middleware ใน `apps/web/vite.config.ts`, prod = R2)
-- `packages/shared-types` — สัญญาข้อมูลระหว่าง api/web/etl (แก้ที่นี่ก่อนเสมอ)
-- สอง Worker อยู่บน host เดียว (`siahra-radar.co`): web ถือ Custom Domain (ทุก path), api ผูก route `/api/*` ซึ่งรัน**ก่อน** origin จึงกิน `/api/*` ไปก่อน — ยัง same-origin (relative `fetch("/api/v1/...")`, WS ใช้ `location.host`, `ALLOWED_ORIGINS` ว่าง) — **deploy แยกกัน**: `npm run deploy:web` / `npm run deploy:api` (ดู `docs/deploy.md` §0.1)
+## Layout
+- `apps/web` — **deploy unit 1** (Worker `siahra-web`; its `wrangler.jsonc` is assets-only, no `main`): React 19 + Vite + Tailwind 4 + three r185 (raw scene graph, not R3F): `src/scene/*` (TerrainTiles LOD, BuildingTiles, FeatureTiles, VegetationTiles, RadarOverlay, floodMask, terrainMaterial shader), `src/components/layout/Map3DCanvas.tsx` assembles every layer, web workers in `src/workers/*`
+- `apps/api` — **deploy unit 2** (Worker `siahra-api`, no `assets` block any more): `src/router.ts` (route table + rate limit + same-origin guard), DOs in `src/durable-objects/*` (ObservationCacheDO = ThaiWater + history + dams + archive, FloodExtentDO, RadarDO, EarthquakeFeedDO), ingestion in `src/ingestion/*`, permanent archive in `src/archive.ts`
+- `apps/etl` — gdal/osmium pipelines: `build:all`, `build:tiles`, `build:building-tiles`, `build:feature-tiles`, `build:landcover-tiles` → small outputs (manifest/overview) land in `apps/web/public/aoi/{code}` (tracked) and the large tiles in `apps/etl/data/tiles` (gitignored, ~5.6 GB, served in dev by middleware in `apps/web/vite.config.ts`; prod = R2)
+- `packages/shared-types` — the data contract between api/web/etl (always change it here first)
+- Both Workers share one host (`siahra-radar.co`): web owns the Custom Domain (all paths), api is bound to the route `/api/*`, which runs **before** the origin and therefore claims `/api/*` first — still same-origin (relative `fetch("/api/v1/...")`, WS uses `location.host`, `ALLOWED_ORIGINS` empty) — **deployed separately**: `npm run deploy:web` / `npm run deploy:api` (see `docs/deploy.md` §0.1)
 
-## รัน
-- `npm run dev` (root) = vite :5173 + wrangler :8787 (ใน worktree ใช้พอร์ตจาก `.env.worktree`) — vite เสิร์ฟ SPA และ proxy `/api` ไป wrangler; **ไม่ต้องมี `apps/web/dist`** อีกแล้ว (build เฉพาะเวลาจะ deploy web หรือเช็คขนาด asset bundle: `npm run build -w apps/web`)
-- ตรวจ: `npx tsc -b` ใน apps/web, `npx tsc --noEmit` ใน apps/api และ apps/etl, `npx oxlint src` ใน apps/web
-- ดูภาพจริง: `playwright-cli -s=<session> open http://localhost:5173` แล้ว `screenshot` (wheel zoom ไม่ทำงาน headless — ใช้ปุ่มซูม/ลาก) ; มี `window.__siahraHandles` ใน dev สำหรับสั่งกล้อง
-- cron ไม่ยิงใน wrangler dev — DO ทุกตัวตั้ง alarm เอง; ยิงมือได้ที่ `GET /__scheduled?cron=*+*+*+*+*`
+## Running it
+- `npm run dev` (root) = vite :5173 + wrangler :8787 (in a worktree, ports come from `.env.worktree`) — vite serves the SPA and proxies `/api` to wrangler; **`apps/web/dist` is no longer needed** (build only to deploy web or to check the asset bundle size: `npm run build -w apps/web`)
+- Checks: `npx tsc -b` in apps/web, `npx tsc --noEmit` in apps/api and apps/etl, `npx oxlint src` in apps/web
+- See it for real: `playwright-cli -s=<session> open http://localhost:5173` then `screenshot` (wheel zoom does not work headless — use the on-screen zoom buttons or drag); `window.__siahraHandles` is available in dev to drive the camera
+- cron does not fire under `wrangler dev` — every DO schedules its own alarm; trigger by hand at `GET /__scheduled?cron=*+*+*+*+*`
 
 ## Orca worktree
-`orca.yaml` → `.orca/setup.sh` → `scripts/setup-worktree.sh` (symlink dataset, copy state, จองพอร์ต, npm ci — ไม่ build web แล้ว) ; Quick Command รัน `.orca/run.sh`; archive hook หยุด dev server ของ worktree นั้นเท่านั้น
+`orca.yaml` → `.orca/setup.sh` → `scripts/setup-worktree.sh` (symlink the dataset, copy state, reserve ports, npm ci — no web build any more); the Quick Command runs `.orca/run.sh`; the archive hook stops only that worktree's dev server
 
-## Git workflow (บังคับด้วย ruleset บน GitHub — `.github/rulesets/main.json`)
-- **ห้าม push ตรงเข้า `main`** ไม่ว่าเล็กหรือด่วนแค่ไหน — แตก branch → เปิด PR เสมอ แม้ผู้ใช้จะพูดว่า "push" ก็ตาม (เว้นแต่สั่ง override ชัด ๆ ในตอนนั้น); ruleset ไม่มี bypass จึง push ตรงจะถูกปฏิเสธอยู่ดี
-- `main` merge ได้เมื่อ status check ผ่านครบ: **Lint / TypeScript / Build** (`.github/workflows/ci.yml` — คำสั่งเดียวกับหัวข้อ "ตรวจ" ด้านบน) ; ห้ามเพิ่ม job ที่ path-filter ไว้เป็น required check (PR ที่ไม่แตะ path นั้นจะรอตลอดกาล)
-- กติกา "PR เป็นอังกฤษ" และ "แก้ UI ต้องมีภาพ" **ยังบังคับใช้เหมือนเดิม แต่ไม่มี CI job คอยจับแล้ว** (`pr-rules.yml` ถูกถอดออกเพราะกิน Actions minutes) — คนตรวจคือ `/implement` ขั้นก่อนเปิด PR และตัวคุณเองเมื่อเปิด PR ด้วยมือ
-- **PR และ commit message ต้องเป็นภาษาอังกฤษทั้งหมด** (subject และ body) — เช็คเองก่อนยิง:
-  `printf '%s' "$TITLE$BODY" | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (PR) และ
-  `git log main..HEAD --format='%s%n%b' | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (commit ทุกอันในสาขา — สองอันนี้แทนกันไม่ได้ PR อังกฤษแต่ commit ไทยก็ยังผิด)
-  เจอแล้วให้เขียนใหม่ (`gh pr edit <n> --title/--body`, `git commit --amend` หรือ `git rebase -i` ถ้ายังไม่ push)
-  ; **คอมเมนต์ในโค้ดยังเขียนไทยได้ตามเดิม** — กติกานี้คุมเฉพาะสิ่งที่คนนอกอ่านก่อนใน repo สาธารณะ คือ log กับหน้ารีวิว
-- **แก้ UI ต้องมีภาพหน้าจอใน PR** — ถ้า PR แตะ `apps/web/src/{components,scene}/**`, `App.tsx`, `main.tsx`, `index.css`, `branding.ts`, `index.html` หรือไฟล์ระดับบนใน `public/` (ไม่รวม `public/aoi/**`) คำอธิบาย PR ต้องมีรูปอย่างน้อย 1 รูป: ถ่ายจาก dev server ด้วย `playwright-cli` แล้ว `scripts/pr-media.sh "$(git branch --show-current)" <png...>` → วาง Markdown ที่มันพิมพ์ลงใน PR body (อัปโหลดเป็น prerelease asset `primg-<branch>` ด้วย `gh` ล้วน ๆ; `pr-image-cleanup.yml` ลบให้เมื่อ PR ปิด) ; เปลี่ยนแค่โค้ดที่ไม่มีผลทางตา → ติดป้าย `no-screenshot`
-- หลัง merge: ลบ branch ทั้ง remote (`gh pr merge --delete-branch` หรือ repo ตั้ง delete-on-merge ไว้แล้ว) และ local (`git branch -d`), แล้ว `git checkout main && git pull` ก่อนเริ่มงานถัดไป
-- แก้ ruleset → แก้ `.github/rulesets/main.json` แล้วรัน `scripts/apply-branch-rules.sh` (idempotent; ต้อง `gh` สิทธิ์ admin)
+## Git workflow (enforced by a GitHub ruleset — `.github/rulesets/main.json`)
+- **Never push straight to `main`**, however small or urgent — branch, then open a PR, even when the user says "push" (unless they explicitly override in that moment); the ruleset has no bypass actors, so a direct push is rejected anyway
+- `main` is mergeable once every status check passes: **Lint / TypeScript / Build** (`.github/workflows/ci.yml` — the same commands as "Checks" above); never make a path-filtered job a required check (a PR that does not touch those paths would wait forever)
+- The "English PRs" and "screenshot for UI changes" rules **still apply, but no CI job enforces them any more** (`pr-rules.yml` was removed because it burned Actions minutes) — they are checked by `/implement` before it opens a PR, and by you when you open one by hand
+- **PR text and commit messages must be entirely in English** (subject and body) — check before you push:
+  `printf '%s' "$TITLE$BODY" | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (the PR) and
+  `git log main..HEAD --format='%s%n%b' | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (every commit on the branch — these two do not substitute for each other; an English PR over Thai commits still breaks the rule)
+  Rewrite whatever it finds (`gh pr edit <n> --title/--body`, `git commit --amend`, or `git rebase -i` if not pushed yet).
+  **Comments inside code may still be written in Thai** — this rule covers what an outsider reads first in a public repo: the log and the review surface
+- **A UI change needs a screenshot in the PR** — if the PR touches `apps/web/src/{components,scene}/**`, `App.tsx`, `main.tsx`, `index.css`, `branding.ts`, `index.html`, or a top-level file in `public/` (not `public/aoi/**`), the description must embed at least one image: capture it from the dev server with `playwright-cli`, run `scripts/pr-media.sh "$(git branch --show-current)" <png...>`, and paste the Markdown it prints into the PR body (uploaded as the prerelease asset `primg-<branch>` using plain `gh`; `pr-image-cleanup.yml` deletes it when the PR closes). No visible change → add the `no-screenshot` label
+- After merging: delete the branch both on the remote (`gh pr merge --delete-branch`, or rely on the repo's delete-on-merge setting) and locally (`git branch -d`), then `git checkout main && git pull` before starting the next task
+- To change the ruleset: edit `.github/rulesets/main.json` and run `scripts/apply-branch-rules.sh` (idempotent; needs `gh` with admin rights)
 
 ## Loop engineering (`.claude/`)
-ลูปมาตรฐานของงานเขียนโค้ด: `/implement <งาน>` → **senior-se** เขียน → **qa-verifier** ตรวจ → วนแก้สูงสุด 3 รอบจน verdict = pass → **docs-sync** อัปเดตเอกสาร → commit → **ถามผู้ใช้ก่อนเปิด PR เสมอ**
-- นิยาม agent อยู่ใน `.claude/agents/{senior-se,qa-verifier,docs-sync}.md` ; คำสั่งอยู่ใน `.claude/commands/{implement,review-fix,babysit-prs}.md`
-- `qa-verifier` **ไม่มี Write/Edit โดยเจตนา** — QA แก้โค้ดเองไม่ได้ นั่นคือสิ่งที่ทำให้ลูปเป็นลูปจริง; มันคืน JSON `{verdict, findings[], screenshots[]}` เพื่อให้เงื่อนไขวนลูปเช็คได้ด้วยเครื่อง ไม่ใช่ด้วยการตีความ
-- QA รันคำสั่งชุดเดียวกับ `ci.yml` เป๊ะ ๆ (ถ้าไม่ตรง QA จะเขียวแต่ CI แดง) บวก visual acceptance ด้วย `playwright-cli` — **ห้ามสตาร์ท dev server เอง** (มีได้ตัวเดียวต่อ worktree; ถ้าไม่รันให้คืน `blocked`)
-- **agent ไม่เปิด PR เอง** ไม่ว่าผู้ใช้จะเคยพูดว่า "push" ไว้ก่อนหน้าหรือไม่ — `.claude/hooks/guard-pr.sh` (PreToolUse) ดัก `gh pr create/merge/ready` และ `git push … main` แล้วบังคับให้ถามผู้ใช้ ; hook เป็นตาข่าย ไม่ใช่ข้ออ้างที่จะไม่ถาม
-- `.claude/settings.json` (tracked) เก็บ hook + allow-list ; `.claude/settings.local.json` เป็นของเครื่องใครเครื่องมัน (gitignored)
+The standard loop for writing code: `/implement <task>` → **senior-se** writes it → **qa-verifier** checks it → up to 3 rounds of fixes until the verdict is `pass` → **docs-sync** updates the docs → commit → **always ask the user before opening a PR**
+- Agent definitions live in `.claude/agents/{senior-se,qa-verifier,docs-sync}.md`; commands in `.claude/commands/{implement,review-fix,babysit-prs}.md`
+- `qa-verifier` **has no Write/Edit tool, deliberately** — QA cannot fix its own findings, and that is what makes the loop a loop; it returns JSON `{verdict, findings[], screenshots[]}` so the loop condition is machine-checkable rather than a matter of interpretation
+- QA runs exactly the commands `ci.yml` runs (if they drift, QA goes green while CI goes red) plus a visual acceptance pass with `playwright-cli` — it **must not start a dev server itself** (one per worktree; if none is running it returns `blocked`)
+- **Agents do not open PRs**, whatever the user said earlier about "push" — `.claude/hooks/guard-pr.sh` (PreToolUse) intercepts `gh pr create/merge/ready` and `git push … main` and forces the question back to the user; the hook is a safety net, not an excuse to skip asking
+- `.claude/settings.json` (tracked) holds the hook and the allow-list; `.claude/settings.local.json` is per-machine (gitignored)
 
 ## Codex PR review — severity policy
 Codex reviews this repo on every push. **Comment only on P1 and P2.** Anything below that is noise:
 it lengthens the review loop without making the product more honest or more correct.
 
 **P1 — comment, blocking**
-- Data-honesty violation: a self-invented forecast number, a hazard layer without the right `HazardLayerDescriptor` kind, `fetchedAt: null` rendered as a real time ("ตอนนี้"), stale data or a dead source disappearing silently instead of degrading visibly
+- Data-honesty violation: a self-invented forecast number, a hazard layer without the right `HazardLayerDescriptor` kind, `fetchedAt: null` rendered as a real time ("now"), stale data or a dead source disappearing silently instead of degrading visibly
 - Correctness bug a user would hit: crash, wrong hazard value, wrong units/CRS, GPU or memory leak in the render loop
 - A `packages/shared-types` contract change whose api/web/etl consumers were not updated
 - Leaked secret or credential
@@ -74,4 +74,4 @@ Naming, style, comment wording, micro-optimisation, personal preference, and any
 - If a push introduces no new P1/P2, post nothing — no "LGTM" re-review
 - Codex review is **advisory**: never add it as a required status check in `.github/rulesets/main.json`
 
-**ฝั่งผู้แก้** (`/review-fix <pr>`): ดึง unresolved threads ด้วย GraphQL `reviewThreads` (คอมเมนต์ Codex เป็น inline review comment — `gh pr view --comments` และ `reviewDecision` มองไม่เห็น) แก้ P1/P2 ทั้งชุด**ในรอบเดียว** push ครั้งเดียว แล้วปิดทุก thread ให้ครบสามอย่าง: **react 👍 → reply บอกว่าแก้อะไรพร้อม sha → resolve** ; `/babysit-prs` (`.claude/commands/babysit-prs.md`) จะเรียกให้เองทุกครั้งที่เจอ thread ค้าง และวนแบบนี้ได้ไม่จำกัดรอบ — หยุดเฉพาะเมื่อ finding เดิมซ้ำทั้งที่แก้ไปแล้ว (P3 ก็ต้องปิด แต่ตอบเหตุผลว่าทำไมไม่แก้ — ห้ามเงียบแล้ว resolve)
+**On the fixing side** (`/review-fix <pr>`): fetch unresolved threads with the GraphQL `reviewThreads` query (Codex comments are inline review comments — `gh pr view --comments` and `reviewDecision` cannot see them), fix the whole set of P1/P2 findings **in one batch**, push once, then close every thread with all three steps: **react 👍 → reply saying what changed, with the sha → resolve**. `/babysit-prs` (`.claude/commands/babysit-prs.md`) dispatches this automatically whenever it finds unresolved threads, with no cap on rounds — it only stops when the same finding repeats unchanged after it was already fixed. (P3 threads must be closed too, but with a reply explaining why they will not be fixed — never resolve silently.)


### PR DESCRIPTION
The agent-facing documentation was still Thai while the rules it describes — English PR text, English commit messages — had already moved to English. These files are read by contributors and by coding agents in a public repo, so they follow the same rule.

Translated in full, keeping every path, command, threshold and caveat intact:

- **`AGENTS.md`** — the whole guide: data-honesty rules, repo layout, how to run it, the Orca worktree chain, the git workflow, loop engineering, and the Codex severity policy. `CLAUDE.md` stays a one-line `@AGENTS.md` import, so both readers get the same single source.
- **`.claude/agents/{senior-se,qa-verifier,docs-sync}.md`**
- **`.claude/commands/{implement,review-fix,babysit-prs}.md`**
- **`.claude/hooks/guard-pr.sh`** — the approval messages a human reads at the moment a `gh pr create` or a push to main is intercepted. Re-tested afterwards: `gh pr create`, `gh -R o/r pr merge`, `/usr/bin/git push origin main` and `$(command -v gh) pr create` still ask; `gh pr view/list/checks` and feature-branch pushes still pass silently.

Deliberately unchanged:

- **Code comments stay Thai**, as `AGENTS.md` continues to state.
- **`README.md` keeps its Thai tagline and the Thai agency names** in the diagram and the attribution table — that is the product's own language and the agencies' official names, not agent documentation.

## Screenshot (required when UI changed)

Not applicable — documentation and `.claude/` config only, no UI paths touched.

## Checklist
- [x] Docs-only change; lint/typecheck/build unaffected and still run in CI
- [x] `guard-pr.sh` re-tested after the message change (ask/allow behaviour unchanged)
- [x] Title, description and commit messages are in English