### PR TITLE
test: add the vitest harness and the first pure unit tests (E1.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Running it
 - `npm run dev` (root) = vite :5173 + wrangler :8787 (in a worktree, ports come from `.env.worktree`) — vite serves the SPA and proxies `/api` to wrangler; **`apps/web/dist` is no longer needed** (build only to deploy web or to check the asset bundle size: `npm run build -w apps/web`)
-- Checks: `npx tsc -b` in apps/web, `npx tsc --noEmit` in apps/api and apps/etl, `npx oxlint src` in apps/web
+- Checks: `npx tsc -b` in apps/web, `npx tsc --noEmit` in apps/api and apps/etl, `npx oxlint src` in apps/web, and `npm test` at the root (= `npm run test -w apps/api && npm run test -w apps/web`; vitest, api tests run in workerd via `@cloudflare/vitest-pool-workers`, web tests are pure modules in `environment: "node"`) — **no CI job runs `npm test` yet**, so it only fails locally
 - See it for real: `playwright-cli -s=<session> open http://localhost:5173` then `screenshot` (wheel zoom does not work headless — use the on-screen zoom buttons or drag); `window.__siahraHandles` is available in dev to drive the camera
 - cron does not fire under `wrangler dev` — every DO schedules its own alarm; trigger by hand at `GET /__scheduled?cron=*+*+*+*+*`
 
@@ -26,7 +26,7 @@
 
 ## Git workflow (enforced by a GitHub ruleset — `.github/rulesets/main.json`)
 - **Never push straight to `main`**, however small or urgent — branch, then open a PR, even when the user says "push" (unless they explicitly override in that moment); the ruleset has no bypass actors, so a direct push is rejected anyway
-- `main` is mergeable once every status check passes: **Lint / TypeScript / Build** (`.github/workflows/ci.yml` — the same commands as "Checks" above); never make a path-filtered job a required check (a PR that does not touch those paths would wait forever)
+- `main` is mergeable once every status check passes: **Lint / TypeScript / Build** (`.github/workflows/ci.yml` — the same `tsc`/`oxlint` commands as "Checks" above; there is no `Test` job, so `npm test` is a local check only); never make a path-filtered job a required check (a PR that does not touch those paths would wait forever)
 - The "English PRs" and "screenshot for UI changes" rules **still apply, but no CI job enforces them any more** (`pr-rules.yml` was removed because it burned Actions minutes) — they are checked by `/implement` before it opens a PR, and by you when you open one by hand
 - **PR text and commit messages must be entirely in English** (subject and body) — check before you push:
   `printf '%s' "$TITLE$BODY" | LC_ALL=C.UTF-8 grep -Pq '[\x{0E00}-\x{0E7F}]'` (the PR) and

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,13 +8,16 @@
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "types": "wrangler types",
-    "dev:raw": "wrangler dev --port 8787 --test-scheduled"
+    "dev:raw": "wrangler dev --port 8787 --test-scheduled",
+    "test": "vitest run"
   },
   "dependencies": {
     "@siahra/shared-types": "*"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.22.0",
     "typescript": "^7.0.2",
+    "vitest": "^4.1.0",
     "wrangler": "^4.123.0"
   }
 }

--- a/apps/api/test/archive.test.ts
+++ b/apps/api/test/archive.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { addDays, bangkokDay, bangkokHour, dayStartMs, keys, BKK_OFFSET_MS } from "../src/archive";
+
+/**
+ * วันในคลังเก็บถาวรคือ "วันแบบกรุงเทพ" (+07:00) ไม่ใช่วัน UTC — เส้นแบ่งวัน
+ * จึงอยู่ที่ 17:00Z ของวันก่อนหน้า ถ้าพลาดตรงนี้ ไฟล์ของเช้าวันใหม่จะไปตกอยู่
+ * ในคีย์ของเมื่อวาน แล้วดัชนีรายวันก็ผิดตามไปทั้งชุด
+ */
+const at = (iso: string) => Date.parse(iso);
+
+describe("bangkokDay / bangkokHour", () => {
+  it("uses the +07:00 offset", () => {
+    expect(BKK_OFFSET_MS).toBe(7 * 3600000);
+  });
+
+  it("rolls the day over at 17:00 UTC, not at midnight UTC", () => {
+    expect(bangkokDay(at("2026-08-18T16:59:59.999Z"))).toBe("2026-08-18");
+    expect(bangkokDay(at("2026-08-18T17:00:00.000Z"))).toBe("2026-08-19");
+    expect(bangkokHour(at("2026-08-18T16:59:59.999Z"))).toBe("23");
+    expect(bangkokHour(at("2026-08-18T17:00:00.000Z"))).toBe("00");
+  });
+
+  it("keeps midnight UTC inside the same Bangkok day", () => {
+    expect(bangkokDay(at("2026-08-18T23:59:59Z"))).toBe("2026-08-19");
+    expect(bangkokDay(at("2026-08-19T00:00:00Z"))).toBe("2026-08-19");
+    expect(bangkokHour(at("2026-08-19T00:00:00Z"))).toBe("07");
+  });
+
+  it("pads the hour to two digits", () => {
+    expect(bangkokHour(at("2026-08-18T18:30:00Z"))).toBe("01");
+    expect(bangkokHour(at("2026-08-18T09:00:00Z"))).toBe("16");
+  });
+
+  it("crosses a month and a year boundary at the same 17:00Z line", () => {
+    expect(bangkokDay(at("2026-08-31T16:59:59Z"))).toBe("2026-08-31");
+    expect(bangkokDay(at("2026-08-31T17:00:00Z"))).toBe("2026-09-01");
+    expect(bangkokDay(at("2026-12-31T17:00:00Z"))).toBe("2027-01-01");
+  });
+});
+
+describe("dayStartMs", () => {
+  it("is 17:00Z on the previous UTC day", () => {
+    expect(dayStartMs("2026-08-19")).toBe(at("2026-08-18T17:00:00Z"));
+  });
+
+  it("round-trips with bangkokDay", () => {
+    for (const day of ["2026-01-01", "2026-02-28", "2026-08-18", "2026-12-31"]) {
+      expect(bangkokDay(dayStartMs(day))).toBe(day);
+      expect(bangkokDay(dayStartMs(day) + 86399999)).toBe(day);
+    }
+  });
+});
+
+describe("addDays", () => {
+  it("is the identity for 0", () => {
+    expect(addDays("2026-08-18", 0)).toBe("2026-08-18");
+  });
+
+  it("steps forward and backward", () => {
+    expect(addDays("2026-08-18", 1)).toBe("2026-08-19");
+    expect(addDays("2026-08-18", -1)).toBe("2026-08-17");
+    expect(addDays("2026-08-18", 7)).toBe("2026-08-25");
+    expect(addDays("2026-08-18", -30)).toBe("2026-07-19");
+  });
+
+  it("crosses month, year and leap-day boundaries", () => {
+    expect(addDays("2026-08-31", 1)).toBe("2026-09-01");
+    expect(addDays("2026-12-31", 1)).toBe("2027-01-01");
+    expect(addDays("2027-01-01", -1)).toBe("2026-12-31");
+    expect(addDays("2028-02-28", 1)).toBe("2028-02-29");
+    expect(addDays("2028-02-29", 1)).toBe("2028-03-01");
+    expect(addDays("2026-02-28", 1)).toBe("2026-03-01");
+  });
+
+  it("walks a whole week one day at a time without drifting", () => {
+    let day = "2026-08-18";
+    const seen: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      day = addDays(day, 1);
+      seen.push(day);
+    }
+    expect(seen).toEqual([
+      "2026-08-19",
+      "2026-08-20",
+      "2026-08-21",
+      "2026-08-22",
+      "2026-08-23",
+      "2026-08-24",
+      "2026-08-25",
+    ]);
+  });
+});
+
+describe("archive keys", () => {
+  it("are stable, prefixed paths derived from the Bangkok day", () => {
+    const day = bangkokDay(at("2026-08-18T17:30:00Z"));
+    expect(day).toBe("2026-08-19");
+    expect(keys.waterlevelDay(day, "10")).toBe("archive/waterlevel/2026-08-19/10.json.gz");
+    expect(keys.snapshot(day, bangkokHour(at("2026-08-18T17:30:00Z")))).toBe(
+      "archive/snapshots/2026-08-19/00.json.gz",
+    );
+    expect(keys.dams(day)).toBe("archive/dams/2026-08-19.json.gz");
+    expect(keys.index(day)).toBe("archive/index/2026-08-19.json");
+  });
+
+  it("makes the flood scene ISO timestamp filesystem-safe", () => {
+    expect(keys.flood("2026-08-18T09:15:30.500Z")).toBe(
+      "archive/flood/2026-08-18T09-15-30-500Z.json.gz",
+    );
+  });
+});

--- a/apps/api/test/rateLimit.test.ts
+++ b/apps/api/test/rateLimit.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { checkLimit, originAllowed } from "../src/rateLimit";
+
+/**
+ * ถังโทเคนเก็บไว้ที่ module scope และไม่มีทางรีเซ็ต (ตั้งใจ — มันคือ state
+ * ของ isolate จริง) เทสแต่ละเคสจึงต้องใช้คู่ scope:key ของตัวเอง และส่ง `now`
+ * เข้าไปเองทุกครั้ง ไม่พึ่ง Date.now()
+ */
+const T0 = Date.UTC(2026, 7, 18, 12, 0, 0);
+
+describe("checkLimit", () => {
+  it("allows a full bucket then refuses when it runs dry", () => {
+    const limit = { perMinute: 10, burst: 0 }; // capacity = 10
+    for (let i = 0; i < 10; i++) {
+      expect(checkLimit("t-drain", "a", limit, T0)).toBeNull();
+    }
+    expect(checkLimit("t-drain", "a", limit, T0)).toBeGreaterThan(0);
+  });
+
+  it("defaults burst to half the sustained rate", () => {
+    const limit = { perMinute: 10 }; // capacity = 10 + ceil(5) = 15
+    for (let i = 0; i < 15; i++) {
+      expect(checkLimit("t-burst", "a", limit, T0)).toBeNull();
+    }
+    expect(checkLimit("t-burst", "a", limit, T0)).not.toBeNull();
+  });
+
+  it("refills at perMinute/60000 tokens per ms", () => {
+    const limit = { perMinute: 60, burst: 0 }; // 1 token per 1000 ms
+    for (let i = 0; i < 60; i++) checkLimit("t-refill", "a", limit, T0);
+    expect(checkLimit("t-refill", "a", limit, T0)).not.toBeNull();
+    // 999 ms ยังไม่ครบหนึ่งโทเคน
+    expect(checkLimit("t-refill", "a", limit, T0 + 999)).not.toBeNull();
+    // ผ่านไปครบวินาที โทเคนที่เติมกลับมาพอให้ผ่าน
+    expect(checkLimit("t-refill", "a", limit, T0 + 3000)).toBeNull();
+  });
+
+  it("never refills above capacity", () => {
+    const limit = { perMinute: 10, burst: 0 };
+    checkLimit("t-cap", "a", limit, T0);
+    // ปล่อยว่างหนึ่งชั่วโมง — ยังเบิกได้แค่ capacity ครั้ง ไม่ใช่ 600
+    for (let i = 0; i < 10; i++) {
+      expect(checkLimit("t-cap", "a", limit, T0 + 3600000)).toBeNull();
+    }
+    expect(checkLimit("t-cap", "a", limit, T0 + 3600000)).not.toBeNull();
+  });
+
+  it("keeps one client's bucket separate from another's", () => {
+    const limit = { perMinute: 5, burst: 0 };
+    for (let i = 0; i < 5; i++) checkLimit("t-split", "a", limit, T0);
+    expect(checkLimit("t-split", "a", limit, T0)).not.toBeNull();
+    expect(checkLimit("t-split", "b", limit, T0)).toBeNull();
+  });
+
+  it("returns retryAfter in whole seconds, scaled to how slow the refill is", () => {
+    const slow = { perMinute: 6, burst: 0 }; // 1 token per 10 s
+    for (let i = 0; i < 6; i++) expect(checkLimit("t-retry", "a", slow, T0)).toBeNull();
+
+    const dry = checkLimit("t-retry", "a", slow, T0);
+    expect(dry).toBe(10); // ขาดเต็มโทเคน = 10 วินาที
+    expect(Number.isInteger(dry)).toBe(true);
+
+    // ครึ่งทาง (5 s) เหลือหนี้ครึ่งโทเคน → 5 วินาที
+    expect(checkLimit("t-retry", "a", slow, T0 + 5000)).toBe(5);
+
+    // คำขอที่ถูกปฏิเสธไม่หักโทเคนเพิ่ม — ยิงซ้ำที่เวลาเดิมได้คำตอบเดิม
+    expect(checkLimit("t-retry", "a", slow, T0 + 5000)).toBe(5);
+  });
+
+  it("still asks for a whole second when the refill is sub-second", () => {
+    const limit = { perMinute: 6000, burst: 0 }; // 100 tokens/s = 10 ms per token
+    for (let i = 0; i < 6000; i++) checkLimit("t-floor", "a", limit, T0);
+    expect(checkLimit("t-floor", "a", limit, T0)).toBe(1);
+  });
+});
+
+function req(url: string, headers: Record<string, string> = {}) {
+  return new Request(url, { headers });
+}
+
+describe("originAllowed", () => {
+  const url = "https://siahra-radar.co/api/v1/health";
+
+  it("allows a request with no Origin and no Sec-Fetch-Site (curl, server-side)", () => {
+    expect(originAllowed(req(url), "")).toBe(true);
+  });
+
+  it("allows same-origin and navigation fetches without an Origin", () => {
+    expect(originAllowed(req(url, { "Sec-Fetch-Site": "same-origin" }), "")).toBe(true);
+    expect(originAllowed(req(url, { "Sec-Fetch-Site": "none" }), "")).toBe(true);
+  });
+
+  it("refuses a cross-site fetch that stripped its Origin", () => {
+    expect(originAllowed(req(url, { "Sec-Fetch-Site": "cross-site" }), "")).toBe(false);
+  });
+
+  it("allows an Origin on our own host", () => {
+    expect(originAllowed(req(url, { Origin: "https://siahra-radar.co" }), "")).toBe(true);
+  });
+
+  it("refuses a third-party Origin", () => {
+    expect(originAllowed(req(url, { Origin: "https://evil.example" }), "")).toBe(false);
+  });
+
+  it("refuses a look-alike host", () => {
+    expect(originAllowed(req(url, { Origin: "https://siahra-radar.co.evil.example" }), "")).toBe(false);
+  });
+
+  it("allows an origin listed in ALLOWED_ORIGINS, ignoring whitespace and blanks", () => {
+    const allow = " https://partner.example , ,https://other.example ";
+    expect(originAllowed(req(url, { Origin: "https://partner.example" }), allow)).toBe(true);
+    expect(originAllowed(req(url, { Origin: "https://other.example" }), allow)).toBe(true);
+    expect(originAllowed(req(url, { Origin: "https://nope.example" }), allow)).toBe(false);
+  });
+
+  it("matches ALLOWED_ORIGINS by full origin, so a different scheme or port is refused", () => {
+    const allow = "https://partner.example";
+    expect(originAllowed(req(url, { Origin: "http://partner.example" }), allow)).toBe(false);
+    expect(originAllowed(req(url, { Origin: "https://partner.example:8443" }), allow)).toBe(false);
+  });
+
+  it("accepts the X-Forwarded-Host the Vite dev proxy sets", () => {
+    const r = req("http://127.0.0.1:8787/api/v1/health", {
+      Origin: "http://localhost:5173",
+      "X-Forwarded-Host": "localhost:5173",
+    });
+    expect(originAllowed(r, "")).toBe(true);
+  });
+
+  it("pairs any loopback origin with a loopback worker host", () => {
+    const r = req("http://127.0.0.1:8787/api/v1/health", { Origin: "http://localhost:5175" });
+    expect(originAllowed(r, "")).toBe(true);
+  });
+
+  it("does not pair a loopback origin with a public worker host", () => {
+    expect(originAllowed(req(url, { Origin: "http://localhost:5173" }), "")).toBe(false);
+  });
+
+  it("refuses an unparseable Origin", () => {
+    expect(originAllowed(req(url, { Origin: "not a url" }), "")).toBe(false);
+  });
+
+  it("refuses the opaque Origin: null", () => {
+    expect(originAllowed(req(url, { Origin: "null" }), "")).toBe(false);
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,25 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+/**
+ * รันเทสของ API ในรันไทม์เดียวกับ production (workerd ผ่าน miniflare) โดยอ่าน
+ * binding ทั้งหมด (R2 + Durable Object ห้าตัว) จาก wrangler.jsonc — รอบนี้ยัง
+ * เป็นเทสของ pure module ล้วน แต่ตั้ง pool ไว้ตั้งแต่ต้นเพื่อให้ E5.5 (เทส
+ * Durable Object ด้วย runInDurableObject / isolatedStorage) เสียบเข้ามาได้
+ * โดยไม่ต้องขยับเวอร์ชัน vitest
+ *
+ * หมายเหตุเวอร์ชัน: ตั้งแต่ @cloudflare/vitest-pool-workers 0.22 (vitest 4)
+ * ไม่มี export `/config` และ defineWorkersConfig อีกแล้ว — ตัว pool มาในรูป
+ * Vite plugin `cloudflareTest()` แทน
+ */
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      isolatedStorage: true,
+      wrangler: { configPath: "./wrangler.jsonc" },
+    }),
+  ],
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "lint": "oxlint",
     "preview": "vite preview",
     "og:image": "node og/build.mjs",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test": "vitest run"
   },
   "dependencies": {
     "@siahra/shared-types": "*",
@@ -29,6 +30,7 @@
     "tailwindcss": "^4.3.3",
     "typescript": "~7.0.2",
     "vite": "^8.2.0",
+    "vitest": "^4.1.0",
     "wrangler": "^4.123.0"
   }
 }

--- a/apps/web/src/hooks/usePermalink.test.ts
+++ b/apps/web/src/hooks/usePermalink.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { parsePermalink, serialisePermalink } from "../lib/permalink";
+
+describe("permalink round-trip", () => {
+  it("carries p, cam, ex, layers and t through serialise → parse", () => {
+    const search = serialisePermalink({
+      provinceCode: "10",
+      pose: { position: [1200, 800, -400], target: [0, 0, 0] },
+      exaggeration: 1.6,
+      layers: { terrain: true, water: true, buildings: false },
+      atIso: "2026-08-18T09:00:00.000Z",
+    });
+
+    // ทุกคีย์ต้องอยู่ในสตริงจริง ไม่ใช่แค่ parse กลับมาได้
+    expect(search).toContain("p=10");
+    expect(search).toContain("cam=1200%2C800%2C-400%2C0%2C0%2C0");
+    expect(search).toContain("ex=1.6");
+    expect(search).toContain("layers=terrain%2Cwater");
+    expect(search).toContain("t=2026-08-18T09%3A00%3A00.000Z");
+
+    expect(parsePermalink(search)).toEqual({
+      provinceCode: "10",
+      pose: { position: [1200, 800, -400], target: [0, 0, 0] },
+      exaggeration: 1.6,
+      layers: ["terrain", "water"],
+      atIso: "2026-08-18T09:00:00.000Z",
+    });
+  });
+
+  it("omits ex at the default exaggeration, and parses that back as null", () => {
+    const search = serialisePermalink({
+      provinceCode: "50",
+      pose: null,
+      exaggeration: 1,
+      layers: { terrain: true },
+      atIso: null,
+    });
+    expect(search).toBe("?p=50");
+    expect(parsePermalink(search).exaggeration).toBeNull();
+  });
+
+  it("omits layers while every layer is on", () => {
+    const search = serialisePermalink({
+      provinceCode: "50",
+      pose: null,
+      exaggeration: 1,
+      layers: { terrain: true, water: true },
+      atIso: null,
+    });
+    expect(search).not.toContain("layers=");
+    expect(parsePermalink(search).layers).toBeNull();
+  });
+
+  // พฤติกรรมที่มีอยู่จริงวันนี้: ปิดครบทุกเลเยอร์จะได้ `layers=` ว่าง ซึ่ง
+  // parse กลับมาเป็น null (= "ใช้ค่า default ของแอป") ไม่ใช่ [] — เทสนี้ตรึงไว้
+  // ตามของจริง ไม่ได้แก้ระหว่างแยกโมดูล
+  it("writes an empty layers list when every layer is off, which parses back as null", () => {
+    const search = serialisePermalink({
+      provinceCode: "50",
+      pose: null,
+      exaggeration: 1,
+      layers: { terrain: false, water: false },
+      atIso: null,
+    });
+    expect(search).toContain("layers=");
+    expect(parsePermalink(search).layers).toBeNull();
+  });
+
+  it("rounds the camera to whole units", () => {
+    const search = serialisePermalink({
+      provinceCode: "10",
+      pose: { position: [1200.4, 800.6, -400.5], target: [0.2, -0.6, 0] },
+      exaggeration: 1,
+      layers: {},
+      atIso: null,
+    });
+    expect(parsePermalink(search).pose).toEqual({
+      position: [1200, 801, -400],
+      target: [0, -1, 0],
+    });
+  });
+});
+
+describe("parsePermalink rejects junk", () => {
+  it("drops a province code that is not two digits", () => {
+    expect(parsePermalink("?p=1").provinceCode).toBeNull();
+    expect(parsePermalink("?p=abc").provinceCode).toBeNull();
+    expect(parsePermalink("p=10").provinceCode).toBe("10");
+  });
+
+  it("drops a camera that is not six finite numbers", () => {
+    expect(parsePermalink("?cam=1,2,3").pose).toBeNull();
+    expect(parsePermalink("?cam=1,2,3,4,5,x").pose).toBeNull();
+  });
+
+  it("drops an unparseable timestamp", () => {
+    expect(parsePermalink("?t=yesterday").atIso).toBeNull();
+    expect(parsePermalink("?t=2026-08-18T09:00:00.000Z").atIso).toBe("2026-08-18T09:00:00.000Z");
+  });
+
+  it("returns all-null for an empty query", () => {
+    expect(parsePermalink("")).toEqual({
+      provinceCode: null,
+      pose: null,
+      exaggeration: null,
+      layers: null,
+      atIso: null,
+    });
+  });
+});

--- a/apps/web/src/hooks/usePermalink.ts
+++ b/apps/web/src/hooks/usePermalink.ts
@@ -1,36 +1,12 @@
 import { useEffect, useMemo, useRef } from "react";
-import type { CameraPose } from "../scene/setupScene";
+import { parsePermalink, serialisePermalink } from "../lib/permalink";
+import type { PermalinkInput, PermalinkState } from "../lib/permalink";
 
-export interface PermalinkState {
-  provinceCode: string | null;
-  pose: CameraPose | null;
-  exaggeration: number | null;
-  layers: string[] | null;
-  atIso: string | null;
-}
+export type { PermalinkState } from "../lib/permalink";
 
 /** Parses the URL once (initial state). */
 export function readPermalink(): PermalinkState {
-  const q = new URLSearchParams(window.location.search);
-  const p = q.get("p");
-  const cam = q.get("cam");
-  let pose: CameraPose | null = null;
-  if (cam) {
-    const n = cam.split(",").map(Number);
-    if (n.length === 6 && n.every((v) => Number.isFinite(v))) {
-      pose = { position: [n[0], n[1], n[2]], target: [n[3], n[4], n[5]] };
-    }
-  }
-  const ex = q.get("ex");
-  const layers = q.get("layers");
-  const t = q.get("t");
-  return {
-    provinceCode: p && /^[0-9]{2}$/.test(p) ? p : null,
-    pose,
-    exaggeration: ex && Number.isFinite(Number(ex)) ? Number(ex) : null,
-    layers: layers ? layers.split(",").filter(Boolean) : null,
-    atIso: t && Number.isFinite(Date.parse(t)) ? t : null,
-  };
+  return parsePermalink(window.location.search);
 }
 
 /**
@@ -38,29 +14,13 @@ export function readPermalink(): PermalinkState {
  * debounced) so a copied link reopens the same province, camera, layers and
  * timeline position.
  */
-export function usePermalinkSync(state: {
-  provinceCode: string;
-  pose: CameraPose | null;
-  exaggeration: number;
-  layers: Record<string, boolean>;
-  atIso: string | null;
-}) {
+export function usePermalinkSync(state: PermalinkInput) {
+  const { provinceCode, pose, exaggeration, layers, atIso } = state;
   const timer = useRef<number | null>(null);
-  const serialized = useMemo(() => {
-    const q = new URLSearchParams();
-    q.set("p", state.provinceCode);
-    if (state.pose) {
-      q.set("cam", [...state.pose.position, ...state.pose.target].map((v) => Math.round(v)).join(","));
-    }
-    if (state.exaggeration !== 1) q.set("ex", String(state.exaggeration));
-    const on = Object.entries(state.layers)
-      .filter(([, v]) => v)
-      .map(([k]) => k);
-    const off = Object.entries(state.layers).filter(([, v]) => !v).length;
-    if (off > 0) q.set("layers", on.join(","));
-    if (state.atIso) q.set("t", state.atIso);
-    return `?${q.toString()}`;
-  }, [state.provinceCode, state.pose, state.exaggeration, state.layers, state.atIso]);
+  const serialized = useMemo(
+    () => serialisePermalink({ provinceCode, pose, exaggeration, layers, atIso }),
+    [provinceCode, pose, exaggeration, layers, atIso],
+  );
 
   useEffect(() => {
     if (timer.current !== null) window.clearTimeout(timer.current);

--- a/apps/web/src/lib/permalink.ts
+++ b/apps/web/src/lib/permalink.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure permalink codec: the URL query string is the only shareable projection
+ * of the UI state, so parsing and serialising it live here — free of React and
+ * of `window` — and `hooks/usePermalink.ts` is the thin binding to the browser.
+ *
+ * The two directions are deliberately *not* symmetric, and that asymmetry is
+ * part of the contract:
+ *   - `ex` is omitted at the default exaggeration of 1, so parsing a link
+ *     without it yields `null` ("use the default"), not `1`
+ *   - `cam` is rounded to whole metres — a link is a viewpoint, not a state dump
+ *   - `layers` is only written when at least one layer is off, so an absent
+ *     `layers` means "everything the app defaults to", not "no layers"
+ */
+import type { CameraPose } from "../scene/setupScene";
+
+export interface PermalinkState {
+  provinceCode: string | null;
+  pose: CameraPose | null;
+  exaggeration: number | null;
+  layers: string[] | null;
+  atIso: string | null;
+}
+
+export interface PermalinkInput {
+  provinceCode: string;
+  pose: CameraPose | null;
+  exaggeration: number;
+  layers: Record<string, boolean>;
+  atIso: string | null;
+}
+
+/** Reads a `?p=..&cam=..` query string (leading `?` optional) into state. */
+export function parsePermalink(search: string): PermalinkState {
+  const q = new URLSearchParams(search);
+  const p = q.get("p");
+  const cam = q.get("cam");
+  let pose: CameraPose | null = null;
+  if (cam) {
+    const n = cam.split(",").map(Number);
+    if (n.length === 6 && n.every((v) => Number.isFinite(v))) {
+      pose = { position: [n[0], n[1], n[2]], target: [n[3], n[4], n[5]] };
+    }
+  }
+  const ex = q.get("ex");
+  const layers = q.get("layers");
+  const t = q.get("t");
+  return {
+    provinceCode: p && /^[0-9]{2}$/.test(p) ? p : null,
+    pose,
+    exaggeration: ex && Number.isFinite(Number(ex)) ? Number(ex) : null,
+    layers: layers ? layers.split(",").filter(Boolean) : null,
+    atIso: t && Number.isFinite(Date.parse(t)) ? t : null,
+  };
+}
+
+/** Renders the shareable UI state as a `?...` query string. */
+export function serialisePermalink(state: PermalinkInput): string {
+  const q = new URLSearchParams();
+  q.set("p", state.provinceCode);
+  if (state.pose) {
+    q.set("cam", [...state.pose.position, ...state.pose.target].map((v) => Math.round(v)).join(","));
+  }
+  if (state.exaggeration !== 1) q.set("ex", String(state.exaggeration));
+  const on = Object.entries(state.layers)
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+  const off = Object.entries(state.layers).filter(([, v]) => !v).length;
+  if (off > 0) q.set("layers", on.join(","));
+  if (state.atIso) q.set("t", state.atIso);
+  return `?${q.toString()}`;
+}

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -22,5 +22,8 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // เทสรันด้วย vitest (ไม่ผ่าน tsc -b) จึงไม่เอาเข้า build graph — ไม่งั้น
+  // ต้องลาก types ของ vitest เข้ามาใน tsconfig ของแอปโดยไม่จำเป็น
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * เทสฝั่ง web เป็น pure module ล้วน (no DOM, no RTL) — environment: "node"
+ * จึงพอ และทำให้ไม่ต้องลง jsdom เพิ่มในรอบ npm ci ของ CI
+ */
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
         "@siahra/shared-types": "*"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.22.0",
         "typescript": "^7.0.2",
+        "vitest": "^4.1.0",
         "wrangler": "^4.123.0"
       }
     },
@@ -57,6 +59,7 @@
         "tailwindcss": "^4.3.3",
         "typescript": "~7.0.2",
         "vite": "^8.2.0",
+        "vitest": "^4.1.0",
         "wrangler": "^4.123.0"
       }
     },
@@ -86,10 +89,29 @@
         }
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.22.0.tgz",
+      "integrity": "sha512-OJv/qikkOgxnKxJ5xrLS7zuOLZhc/6iziU+llqZm4tiQf2CJUYwlMuXN68VaWIQebORd1AUx4w6A0oy8XRbuaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260815.0-alpha",
+        "wrangler": "4.124.0",
+        "zod": "4.4.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
-      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
       "cpu": [
         "x64"
       ],
@@ -104,9 +126,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +143,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
-      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
       "cpu": [
         "x64"
       ],
@@ -138,9 +160,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
       "cpu": [
         "arm64"
       ],
@@ -155,9 +177,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
-      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
       "cpu": [
         "x64"
       ],
@@ -1974,6 +1996,13 @@
       "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
@@ -4597,16 +4626,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-voronoi": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
       "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/earcut": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
       "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -5046,6 +5100,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
@@ -5084,6 +5251,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -5100,6 +5277,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -5112,6 +5299,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -5170,6 +5364,13 @@
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -5263,6 +5464,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -5315,6 +5523,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
@@ -5339,6 +5557,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5861,16 +6089,16 @@
       "license": "MIT"
     },
     "node_modules/miniflare": {
-      "version": "5.20260811.1-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
-      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260811.1",
+        "workerd": "1.20260815.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -5923,6 +6151,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/oxlint": {
@@ -6257,6 +6499,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6290,6 +6539,20 @@
       "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
       "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
       "license": "BDS-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -6377,6 +6640,23 @@
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6399,6 +6679,16 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/topojson-client": {
       "version": "3.1.0",
@@ -6613,6 +6903,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web": {
       "resolved": "apps/web",
       "link": true
@@ -6632,10 +7012,27 @@
         "url": "https://github.com/sindresorhus/which-command?sponsor=1"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/workerd": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
-      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -6646,17 +7043,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260811.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
-        "@cloudflare/workerd-linux-64": "1.20260811.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
-        "@cloudflare/workerd-windows-64": "1.20260811.1"
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.123.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
-      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -6664,10 +7061,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260811.1-alpha",
+        "miniflare": "5.20260815.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260811.1"
+        "workerd": "1.20260815.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -6681,7 +7078,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260811.1"
+        "@cloudflare/workers-types": "^5.20260815.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -6802,6 +7199,16 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/shared-types": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:web": "npm run build -w apps/web",
     "build:aoi": "npm run build:all -w apps/etl",
     "deploy:web": "npm run build -w apps/web && npm run deploy -w apps/web",
-    "deploy:api": "npm run deploy -w apps/api"
+    "deploy:api": "npm run deploy -w apps/api",
+    "test": "npm run test -w apps/api && npm run test -w apps/web"
   },
   "devDependencies": {
     "concurrently": "^10.0.5"


### PR DESCRIPTION
Roadmap task **E1.1** — the repository's first test harness, plus unit tests for the three pure modules later tasks build on. Closes the "no test runner" gap and unblocks E1.3 (the CI `Test` job) and E5.5 (Durable Object tests).

## What landed

Root `npm test` = `npm run test -w apps/api && npm run test -w apps/web`. It runs offline, needs no dev server and no browser install, and was verified after a cold `npm ci`.

**`apps/api`** runs under `@cloudflare/vitest-pool-workers`, so tests execute in workerd against the real `wrangler.jsonc` bindings with `isolatedStorage: true`.

- `test/rateLimit.test.ts` — 8 `checkLimit` cases (drain, default burst, refill rate, capacity clamp after idle, per-client isolation, `retryAfter` scaling, whole seconds, rejections not double-charging) and 12 `originAllowed` cases.
- `test/archive.test.ts` — `bangkokDay`/`bangkokHour` asserted from both sides of the 17:00 UTC day boundary (`16:59:59.999Z` → `2026-08-18`/`23`, `17:00:00.000Z` → `2026-08-19`/`00`), month/year crossings, `dayStartMs` round-trip, `addDays` including the 2028 leap day, and the archive key shapes.

**`apps/web`** runs plain vitest with `environment: "node"` over pure modules only — no jsdom, no RTL, nothing that touches the dev server.

- `src/lib/permalink.ts` is new: `parsePermalink`/`serialisePermalink` lifted **verbatim** out of `src/hooks/usePermalink.ts`, which now delegates to them. The only body change is `new URLSearchParams(window.location.search)` → `new URLSearchParams(search)`, with `readPermalink()` supplying `window.location.search`. It imports `CameraPose` as a type only, so no three.js is loaded in the node-env test.
- `src/hooks/usePermalink.test.ts` — round-trip for `p`, `cam`, `ex`, `layers`, `t`, the three deliberate asymmetries, and junk-input rejection.

## Decisions worth recording

**vitest pinned to `^4.1.0`** in both workspaces — that is the peer range `@cloudflare/vitest-pool-workers@0.22.0` declares (`vitest`, `@vitest/runner`, `@vitest/snapshot` all `^4.1.0`). E5.5 can adopt the pool for the DO tests with no version bump.

**`defineWorkersConfig` no longer exists in 0.22.0.** The package's `exports` map has only `.`, `./types` and `./codemods/vitest-v3-to-v4` — importing `./config` fails with `Missing "./config" specifier`. The package ships its own codemod that rewrites `defineWorkersProject({ test: { poolOptions: { workers: X } } })` into `defineConfig({ plugins: [cloudflareTest(X)] })`, and that is the shape used here. The authorised fallback to plain vitest was **not** needed — pool-workers installed and ran clean, so the pin is verified rather than asserted.

**The pool is really workerd, not a fast no-op.** QA confirmed this independently: `await import("cloudflare:test")` resolves under `cloudflareTest()` and fails with `Cannot find package 'cloudflare:test'` under a plain node-pool control config; `--reporter=verbose` lists all API tests as passing with none skipped; a deliberately broken assertion exits 1.

## One pre-existing defect pinned, not fixed

With **every** layer switched off, `serialisePermalink` emits an empty `layers=` and `parsePermalink` reads that back as `null` — "use the app defaults" — so an all-layers-off link reopens with layers on. This is on `main` today (byte-compared against `git show main:apps/web/src/hooks/usePermalink.ts`); the test pins the current behaviour with `toBeNull()` because E1.1's acceptance criteria forbid changing runtime behaviour during a pure extraction. The assertion is a record of the defect, not an endorsement — it deserves a follow-up task.

## Checks

`npm test` exit 0 (42 tests, 3 files, no network) · `npx tsc -b` in `apps/web` · `npx tsc --noEmit` in `apps/api` and `apps/etl` · `npx oxlint src` in `apps/web` · `npm run build -w apps/web` · `wrangler deploy --dry-run` for both Workers · `npm ci --dry-run` in sync.

No CI job runs `npm test` yet — that is roadmap task **E1.3**, a standalone change to `ci.yml`. `.github/pull_request_template.md` and `.claude/agents/qa-verifier.md` also still enumerate the checks without `npm test`; both are in E1.3's `Touches:` list and are expected to lag until it runs.

`AGENTS.md` was updated by docs-sync: the "Checks" line now names `npm test` and states that no CI job runs it, and the "Git workflow" parenthetical was narrowed so it no longer claims CI runs the same command set.

## No screenshot

The diff touches no visual surface — only `src/hooks/usePermalink.ts`, `src/lib/permalink.ts` and the test files under `apps/web/src`. No `components/**`, `scene/**`, `App.tsx`, `main.tsx`, `index.css`, `branding.ts`, `index.html` or top-level `public/`. Labelled `no-screenshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
