### PR TITLE
fix(web): make the methodology page scroll again

### DIFF
--- a/apps/web/src/pages/MethodologyPage.tsx
+++ b/apps/web/src/pages/MethodologyPage.tsx
@@ -35,7 +35,16 @@ export default function MethodologyPage({ slug }: { slug: string }) {
     document.title = `${t(doc ? doc.titleKey : "methodology.notFound")} — ${BRAND.name}`;
   }, [doc, t]);
   return (
-    <div className="min-h-screen w-full overflow-y-auto bg-[var(--color-bg)] px-5 py-8">
+    // ความสูงตรึงเท่าจอ ไม่ใช่ `min-h-screen`: `body` ตั้ง `overflow: hidden` ไว้
+    // เพื่อไม่ให้หน้าแผนที่เลื่อนหลุด (index.css) — ถ้ากล่องนี้เป็น min-height มันจะ
+    // ยืดตามเนื้อหาจนสูงเกินจอ `overflow-y-auto` ก็ไม่ทำงาน (ไม่มีอะไรล้นในกล่องเอง)
+    // แล้วส่วนที่เกินไปโดน `body` ตัดทิ้ง เอกสารยาว ๆ จึงอ่านต่อไม่ได้เลย
+    //
+    // ใช้ `dvh` ไม่ใช่ `vh` (ต่างจาก App.tsx ที่เป็น `h-screen` ได้เพราะมันคือ
+    // `overflow-hidden` ไม่เคยต้องเลื่อนไปถึงขอบล่าง): บนมือถือ `100vh` สูงเกิน
+    // ส่วนที่มองเห็นจริงตอนแถบ URL กางอยู่ ก้นเอกสารจะไปหลบใต้แถบนั้น ซึ่งก็คือ
+    // บั๊กเดิมในรูปแบบที่เล็กลง
+    <div className="h-dvh w-full overflow-y-auto bg-[var(--color-bg)] px-5 py-8">
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-5">
         {/* หน้านี้ไม่มีแถบบน จึงต้องมีปุ่มสลับภาษาของตัวเอง ไม่งั้นผู้อ่านที่มาจาก
             ลิงก์ `?lang=` เปลี่ยนภาษาที่นี่ไม่ได้เลย (ใช้ปุ่มตัวเดียวกับ TopBar) */}


### PR DESCRIPTION
## The bug

`/methodology/<slug>` could not be scrolled: everything below the first viewport was unreachable, so the lower half of every methodology document — the limitations section of `lowland`, most of `flood-exposure` — was simply unreadable in the browser.

## Cause

`index.css` sets `body { overflow: hidden }` so the map can never scroll away. The methodology page's container was `min-h-screen`, and a min-height box **grows with its content**: it never overflows itself, so its own `overflow-y-auto` has nothing to scroll, and the part that sticks out past the viewport is clipped by `body` instead. Neither element scrolls, so nothing does.

## Fix

Pin the container to the viewport height so it becomes the scroller — one class, `min-h-screen` → `h-dvh`.

`h-dvh` rather than the `h-screen` used in `App.tsx`: that page is `overflow-hidden` and never has to reach a bottom edge, so `100vh` overshooting the visible area is harmless there. Here it is not — with `100vh` the end of a document sits under a mobile browser's URL bar, which is the same bug in a smaller form.

## Verification

Measured against a running dev server (`clientHeight` → `scrollHeight`, then scrolled to the end):

| Page | Viewport | Content | Scrolled to |
| --- | --- | --- | --- |
| `lowland` | 1280×720 | 1580 px | 860 ✅ |
| `lowland` | 390×844 | 2768 px | 1924 ✅ |
| `flood-exposure` | 1280×720 | 4208 px | 3488 ✅ |
| map page `/` | 1280×720 | canvas still renders, `body` overflow unchanged | ✅ |

`npx oxlint src worker` and `npx tsc -b` are clean in `apps/web`; `npm run test -w apps/web` passes (160 tests).

## Screenshots

Top of `/methodology/lowland`, and the same page scrolled to the end — the part that was previously unreachable:

![methodology-top](https://github.com/flukelaster/SIAHRA/releases/download/primg-fix-methodology-page-scroll/methodology-top.png)
![methodology-scrolled-to-bottom](https://github.com/flukelaster/SIAHRA/releases/download/primg-fix-methodology-page-scroll/methodology-scrolled-to-bottom.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnMNdHbDhAXuApYrixqRK8
