### PR TITLE
feat(web): add a GitHub source-repo link to the top bar

### DIFF
--- a/apps/web/src/branding.ts
+++ b/apps/web/src/branding.ts
@@ -11,6 +11,14 @@ export const BRAND = {
   /** Browser tab / document title. */
   documentTitle: "SIAHRA — Spatial Intelligence Atlas for Hazard & Resilience Analytics",
   copyrightYear: 2026,
+  /**
+   * Public source repository. The app is open source, so the header carries a
+   * link back to it — one URL, declared here with the rest of the identity
+   * rather than typed into a component. (Unrelated to `methodologyUrl`, which
+   * stays on the in-app `/methodology` page by the decision in
+   * docs/roadmap.md §4.)
+   */
+  repoUrl: "https://github.com/flukelaster/SIAHRA",
 } as const;
 
 /**

--- a/apps/web/src/components/layout/GithubMark.tsx
+++ b/apps/web/src/components/layout/GithubMark.tsx
@@ -1,0 +1,24 @@
+/**
+ * GitHub Octocat mark (official path, MIT-licensed logo asset from GitHub's
+ * Octicons set) — drawn inline because `lucide-react` v1 dropped every brand
+ * icon, so there is no icon-set import that would give us this glyph.
+ *
+ * `currentColor` on purpose: the link that carries it inherits the same hover
+ * colours as the share/snapshot buttons next to it.
+ */
+export function GithubMark({ size = 15, className }: { size?: number; className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      width={size}
+      height={size}
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -2,6 +2,7 @@ import { Camera, Check, Link2, Search } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { BRAND } from "../../branding";
 import { BrandMark } from "./BrandMark";
+import { GithubMark } from "./GithubMark";
 import { LanguageToggle } from "./LanguageToggle";
 import type { Province } from "../../data/types";
 import { useLang } from "../../i18n/context";
@@ -17,7 +18,7 @@ export interface SearchPlace {
   lat: number;
 }
 
-/** Floating header bar over the map: brand, search (province/amphoe/station/dam), share, snapshot. */
+/** Floating header bar over the map: brand, search (province/amphoe/station/dam), share, snapshot, source repo. */
 export function TopBar({
   provinces,
   places,
@@ -167,6 +168,18 @@ export function TopBar({
         >
           <Camera size={14} />
         </button>
+        {/* ทางเข้าซอร์สโค้ด — โครงการเป็นโอเพนซอร์ส ลิงก์จึงอยู่ในแถบบนตลอด
+            รวมถึงจอแคบ (ปุ่มไอคอนล้วน กินที่เท่าปุ่มบันทึกภาพ) */}
+        <a
+          href={BRAND.repoUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          title={t("topbar.repoTitle")}
+          aria-label={t("topbar.repoTitle")}
+          className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 text-[var(--color-fg-muted)] transition-colors hover:border-white/25 hover:text-[var(--color-fg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+        >
+          <GithubMark size={15} />
+        </a>
       </div>
 
       <LanguageToggle compact={compact} />

--- a/apps/web/src/i18n/en.ts
+++ b/apps/web/src/i18n/en.ts
@@ -125,6 +125,7 @@ export const en: Record<keyof typeof th, string> = {
   "topbar.shareTitle": "Copy a link to this view",
   "topbar.snapshotTitle": "Save a map image",
   "topbar.sources": "Data sources",
+  "topbar.repoTitle": "Source code on GitHub (open source)",
 
   // ── Province picker ───────────────────────────────────────────────────
   "province.select": "Select a province",

--- a/apps/web/src/i18n/th.ts
+++ b/apps/web/src/i18n/th.ts
@@ -121,6 +121,7 @@ export const th = {
   "topbar.shareTitle": "คัดลอกลิงก์มุมมองนี้",
   "topbar.snapshotTitle": "บันทึกภาพแผนที่",
   "topbar.sources": "แหล่งข้อมูล",
+  "topbar.repoTitle": "ซอร์สโค้ดบน GitHub (โอเพนซอร์ส)",
 
   // ── ตัวเลือกจังหวัด ───────────────────────────────────────────────────
   "province.select": "เลือกจังหวัด",


### PR DESCRIPTION
## What

The project is open source, but the app never pointed anywhere near its source. This adds the usual entrance: an icon-only GitHub link in the top bar, next to share and snapshot.

- `apps/web/src/components/layout/GithubMark.tsx` (new) — the Octocat mark drawn inline, because `lucide-react` v1 ships no brand icons; it paints with `currentColor` so it hovers like the buttons beside it
- `apps/web/src/branding.ts` — `BRAND.repoUrl` lives with the rest of the product identity instead of being typed into a component. This is unrelated to `methodologyUrl`, which stays on the in-app `/methodology` page per `docs/roadmap.md` §4
- `apps/web/src/components/layout/TopBar.tsx` — `<a target="_blank" rel="noreferrer noopener">` styled exactly like the snapshot button (h-8 w-8), with `title` and `aria-label`
- `i18n/th.ts` + `i18n/en.ts` — one new key, `topbar.repoTitle`

No data layer, descriptor, API route or binding is touched.

## Screenshots

Desktop (1440×900), top bar cropped:

![topbar-github-desktop](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-show-github/topbar-github-desktop.png)

Compact (390×844) — the bar still does not wrap; the search field loses ~38px, and its placeholder was already truncated before this change:

![topbar-github-mobile](https://github.com/flukelaster/SIAHRA/releases/download/primg-flukelaster-show-github/topbar-github-mobile.png)

## Checks

`npx tsc -b` and `npx oxlint src worker` in `apps/web`, plus root `npm test` (api + web + etl) — all green locally.
