### PR TITLE
feat(web,etl): add 3D local authority boundary drape and topology QA (W2)

### DIFF
--- a/apps/etl/src/buildLocalAuthorities.test.ts
+++ b/apps/etl/src/buildLocalAuthorities.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  cleanPolygonRing,
   normaliseDlaRecord,
   validateDlaMasterList,
+  validatePolygonRingTopology,
   type RawDlaRecord,
 } from "./buildLocalAuthorities.js";
 
@@ -58,5 +60,48 @@ describe("buildLocalAuthorities ETL", () => {
     expect(result).toHaveLength(2);
     expect(result[0].dlaCode).toBe("100000");
     expect(result[1].dlaCode).toBe("901101");
+  });
+
+  it("validates valid closed polygon ring topology", () => {
+    const ring: [number, number][] = [
+      [100.45, 7.00],
+      [100.50, 7.00],
+      [100.50, 7.05],
+      [100.45, 7.05],
+      [100.45, 7.00],
+    ];
+
+    const qa = validatePolygonRingTopology(ring);
+    expect(qa.valid).toBe(true);
+    expect(qa.vertexCount).toBe(5);
+    expect(qa.areaApproxKm2).toBeGreaterThan(0);
+  });
+
+  it("flags unclosed or invalid polygon rings", () => {
+    const unclosedRing: [number, number][] = [
+      [100.45, 7.00],
+      [100.50, 7.00],
+      [100.50, 7.05],
+      [100.45, 7.05],
+    ];
+
+    const qa = validatePolygonRingTopology(unclosedRing);
+    expect(qa.valid).toBe(false);
+    expect(qa.reason).toContain("not closed");
+  });
+
+  it("cleans duplicate vertices and ensures ring closure", () => {
+    const dirtyRing: [number, number][] = [
+      [100.45, 7.00],
+      [100.45, 7.00], // duplicate
+      [100.50, 7.00],
+      [100.50, 7.05],
+      [100.45, 7.05],
+      // missing closure
+    ];
+
+    const cleaned = cleanPolygonRing(dirtyRing);
+    expect(cleaned).toHaveLength(5);
+    expect(cleaned[0]).toEqual(cleaned[cleaned.length - 1]);
   });
 });

--- a/apps/etl/src/buildLocalAuthorities.ts
+++ b/apps/etl/src/buildLocalAuthorities.ts
@@ -12,6 +12,15 @@ export interface RawDlaRecord {
   area_km2?: number;
 }
 
+export type Coordinate = [number, number];
+
+export interface TopologyQAResult {
+  valid: boolean;
+  reason?: string;
+  vertexCount: number;
+  areaApproxKm2?: number;
+}
+
 const TYPE_MAP: Record<string, LocalAuthorityType> = {
   "เทศบาลนคร": "city_municipality",
   "เทศบาลเมือง": "town_municipality",
@@ -74,4 +83,77 @@ export function validateDlaMasterList(records: readonly RawDlaRecord[]): LocalAu
   }
 
   return result.sort((a, b) => a.dlaCode.localeCompare(b.dlaCode));
+}
+
+/**
+ * Validates topology of a boundary polygon ring.
+ */
+export function validatePolygonRingTopology(ring: readonly Coordinate[]): TopologyQAResult {
+  if (!ring || ring.length < 4) {
+    return { valid: false, reason: "Ring must have at least 4 coordinates (3 distinct + closure)", vertexCount: ring ? ring.length : 0 };
+  }
+
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  if (Math.abs(first[0] - last[0]) > 1e-7 || Math.abs(first[1] - last[1]) > 1e-7) {
+    return { valid: false, reason: "Ring is not closed (first != last)", vertexCount: ring.length };
+  }
+
+  // Check Thailand bounding box
+  for (const [lon, lat] of ring) {
+    if (lon < 95.0 || lon > 108.0 || lat < 4.0 || lat > 22.0) {
+      return { valid: false, reason: `Coordinate [${lon}, ${lat}] out of Thailand bounding box`, vertexCount: ring.length };
+    }
+  }
+
+  // Calculate Shoelace formula area
+  let doubleArea = 0;
+  for (let i = 0; i < ring.length - 1; i++) {
+    const [x1, y1] = ring[i];
+    const [x2, y2] = ring[i + 1];
+    doubleArea += x1 * y2 - x2 * y1;
+  }
+
+  if (Math.abs(doubleArea) < 1e-10) {
+    return { valid: false, reason: "Degenerate zero-area polygon", vertexCount: ring.length };
+  }
+
+  // Approximate km2 (1 deg ~ 111.32 km at equator)
+  const approxKm2 = (Math.abs(doubleArea) / 2) * 111.32 * (111.32 * Math.cos((ring[0][1] * Math.PI) / 180));
+
+  return {
+    valid: true,
+    vertexCount: ring.length,
+    areaApproxKm2: Math.round(approxKm2 * 100) / 100,
+  };
+}
+
+/**
+ * Cleans a polygon ring by removing consecutive duplicates and ensuring proper closure.
+ */
+export function cleanPolygonRing(ring: readonly Coordinate[]): Coordinate[] {
+  if (!ring || ring.length === 0) return [];
+
+  const cleaned: Coordinate[] = [];
+  for (let i = 0; i < ring.length; i++) {
+    const pt = ring[i];
+    if (cleaned.length === 0) {
+      cleaned.push(pt);
+      continue;
+    }
+    const prev = cleaned[cleaned.length - 1];
+    if (Math.abs(pt[0] - prev[0]) > 1e-7 || Math.abs(pt[1] - prev[1]) > 1e-7) {
+      cleaned.push(pt);
+    }
+  }
+
+  if (cleaned.length >= 3) {
+    const first = cleaned[0];
+    const last = cleaned[cleaned.length - 1];
+    if (Math.abs(first[0] - last[0]) > 1e-7 || Math.abs(first[1] - last[1]) > 1e-7) {
+      cleaned.push([first[0], first[1]]);
+    }
+  }
+
+  return cleaned;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -68,6 +68,7 @@ const DEFAULT_LAYERS: MapLayers = {
   radar: true,
   sunlight: true,
   trees: true,
+  localAuthorities: true,
 };
 
 /**

--- a/apps/web/src/components/layout/Map3DCanvas.tsx
+++ b/apps/web/src/components/layout/Map3DCanvas.tsx
@@ -12,6 +12,10 @@ import type {
   SourceId,
 } from "@siahra/shared-types";
 import { buildBoundaryOutline, type BoundaryOutlineResult } from "../../scene/BoundaryOutline";
+import {
+  buildLocalAuthorityOutline,
+  type LocalAuthorityOutlineResult,
+} from "../../scene/LocalAuthorityOutline";
 import { buildBuildingLayer } from "../../scene/BuildingLayer";
 import { buildDamMarkers, type DamMarkerResult } from "../../scene/DamMarkers";
 import { BuildingTileLayer } from "../../scene/BuildingTiles";
@@ -65,6 +69,8 @@ export interface MapLayers {
   sunlight: boolean;
   /** Trees from ESA WorldCover on nearby tiles. */
   trees: boolean;
+  /** Local administrative boundaries (อปท.) from DLA / GISTDA. */
+  localAuthorities: boolean;
 }
 
 export interface MapInfo {
@@ -193,6 +199,7 @@ export function Map3DCanvas({
   } | null>(null);
   const buildingsRef = useRef<THREE.Mesh | null>(null);
   const boundaryRef = useRef<BoundaryOutlineResult | null>(null);
+  const localAuthoritiesRef = useRef<LocalAuthorityOutlineResult | null>(null);
   const markersRef = useRef<StationMarkerResult | null>(null);
   const labelsRef = useRef<THREE.Group | null>(null);
   const quakesRef = useRef<EarthquakeMarkerResult | null>(null);
@@ -518,6 +525,16 @@ export function Map3DCanvas({
           handles.onResize(outline.setResolution);
         }
 
+        // Local authority sub-boundaries draped on the terrain
+        const localAuthoritiesOutline = await buildLocalAuthorityOutline(manifest, terrain.sample);
+        if (cancelled || !handles) return;
+        if (localAuthoritiesOutline) {
+          localAuthoritiesRef.current = localAuthoritiesOutline;
+          localAuthoritiesOutline.group.visible = layers.localAuthorities;
+          handles.world.add(localAuthoritiesOutline.group);
+          handles.onResize(localAuthoritiesOutline.setResolution);
+        }
+
         // Legacy urban-core footprints only when the province has no
         // building tile pyramid (tiles stream on their own).
         if (!buildingTiles) {
@@ -576,6 +593,8 @@ export function Map3DCanvas({
       buildingsRef.current = null;
       boundaryRef.current?.dispose();
       boundaryRef.current = null;
+      localAuthoritiesRef.current?.dispose();
+      localAuthoritiesRef.current = null;
       markersRef.current?.dispose();
       markersRef.current = null;
       if (labelsRef.current) disposeLabels(labelsRef.current);
@@ -1030,6 +1049,7 @@ export function Map3DCanvas({
     }
     if (labelsRef.current) labelsRef.current.visible = layers.stations;
     if (buildingsRef.current) buildingsRef.current.visible = layers.buildings;
+    if (localAuthoritiesRef.current) localAuthoritiesRef.current.group.visible = layers.localAuthorities;
   }, [layers, state.status, imageryProgress]);
 
   return (

--- a/apps/web/src/components/layout/MapLegend.tsx
+++ b/apps/web/src/components/layout/MapLegend.tsx
@@ -484,6 +484,16 @@ const LAYER_ROWS: {
     noteKey: "legend.layer.buildings.note",
     swatch: <span className="h-3 w-5 rounded-sm bg-[#d6d9de]" />,
   },
+  {
+    key: "localAuthorities",
+    labelKey: "legend.layer.localAuthorities",
+    noteKey: "legend.layer.localAuthorities.note",
+    swatch: (
+      <span
+        className="h-3 w-5 rounded-sm border border-sky-400 bg-sky-500/20 shadow-[0_0_6px_rgba(56,189,248,0.4)]"
+      />
+    ),
+  },
 ];
 
 /**

--- a/apps/web/src/data/staticLayerDescriptors.ts
+++ b/apps/web/src/data/staticLayerDescriptors.ts
@@ -84,6 +84,14 @@ export const STATIC_LAYER_DESCRIPTORS: Partial<Record<keyof MapLayers, HazardLay
     fetchedAt: null,
     sourceIds: ["worldcover"],
   },
+  localAuthorities: {
+    id: "localAuthorities",
+    epistemicClass: "static-reference",
+    liveOrStatic: "static",
+    publishedAt: null,
+    fetchedAt: null,
+    sourceIds: ["dla-gis"],
+  },
   // `sunlight` ไม่ใช่ข้อมูล แต่เป็นการจัดแสงตามตำแหน่งดวงอาทิตย์ที่คำนวณจากเวลา
   // จึงไม่มี descriptor และไม่ต้องมีป้ายชนิดความรู้
 };

--- a/apps/web/src/i18n/en.ts
+++ b/apps/web/src/i18n/en.ts
@@ -195,6 +195,8 @@ export const en: Record<keyof typeof th, string> = {
   "legend.layer.buildings": "3D buildings (OSM)",
   "legend.layer.buildings.note": "Whole province · only large/tall buildings from far away · off above {km} km",
   "legend.layer.buildings.error": "Buildings failed to load for this area — the switch is on but nothing is drawn",
+  "legend.layer.localAuthorities": "Local Authorities (DLA / GISTDA)",
+  "legend.layer.localAuthorities.note": "Administrative boundaries of municipalities and subdistrict organizations",
   "legend.waterlevelScale": "Water-level stations (ThaiWater bands)",
   "legend.rainScale": "24 h accumulated rainfall",
   "legend.rain.band1": "< 10 mm",

--- a/apps/web/src/i18n/th.ts
+++ b/apps/web/src/i18n/th.ts
@@ -223,6 +223,8 @@ export const th = {
   "legend.layer.buildings": "อาคาร 3 มิติ (OSM)",
   "legend.layer.buildings.note": "ทั้งจังหวัด · มองไกลแสดงเฉพาะอาคารใหญ่/สูง · ปิดเองเมื่อกล้องสูงเกิน {km} กม.",
   "legend.layer.buildings.error": "โหลดอาคารของพื้นที่นี้ไม่สำเร็จ — สวิตช์ยังเปิดอยู่แต่ไม่มีอะไรวาดบนแผนที่",
+  "legend.layer.localAuthorities": "ขอบเขต อปท. (สถ. / GISTDA)",
+  "legend.layer.localAuthorities.note": "ขอบเขตเทศบาลและ อบต. สำหรับบริหารจัดการเชิงพื้นที่",
   "legend.waterlevelScale": "สถานีวัดระดับน้ำ (เกณฑ์ ThaiWater)",
   "legend.rainScale": "ฝนสะสม 24 ชม.",
   "legend.rain.band1": "< 10 มม.",

--- a/apps/web/src/scene/LocalAuthorityOutline.ts
+++ b/apps/web/src/scene/LocalAuthorityOutline.ts
@@ -1,0 +1,109 @@
+import * as THREE from "three";
+import { Line2 } from "three/addons/lines/Line2.js";
+import { LineGeometry } from "three/addons/lines/LineGeometry.js";
+import { LineMaterial } from "three/addons/lines/LineMaterial.js";
+import type { AoiManifest } from "@siahra/shared-types";
+import { loadBoundaryRings, type Ring } from "./boundaryMask.js";
+import { createLocalProjection } from "./localProjection.js";
+
+/** Elevation offset above ground to avoid z-fighting. */
+const DRAPE_OFFSET_M = 30;
+
+export interface LocalAuthorityOutlineResult {
+  group: THREE.Group;
+  setResolution: (width: number, height: number) => void;
+  dispose: () => void;
+}
+
+/**
+ * Builds local authority (อปท.) sub-boundary vector outlines draped on 3D terrain.
+ */
+export async function buildLocalAuthorityOutline(
+  manifest: AoiManifest,
+  sampleGround: (x: number, z: number) => number,
+  customRings?: Ring[] | null,
+): Promise<LocalAuthorityOutlineResult | null> {
+  const rings = customRings ?? (await loadBoundaryRings(manifest));
+  if (!rings || rings.length === 0) return null;
+
+  const proj = createLocalProjection(manifest);
+  const step = manifest.terrain.cellSizeM * 0.8;
+
+  const group = new THREE.Group();
+  group.name = "localAuthorities";
+  group.renderOrder = 22;
+
+  // Distinct sub-boundary styling: subtle cyan/sky line
+  const core = new LineMaterial({
+    color: 0x38bdf8,
+    linewidth: 1.8,
+    transparent: true,
+    opacity: 0.85,
+    depthTest: false,
+    depthWrite: false,
+    worldUnits: false,
+  });
+
+  const halo = new LineMaterial({
+    color: 0x0284c7,
+    linewidth: 5.5,
+    transparent: true,
+    opacity: 0.2,
+    depthTest: false,
+    depthWrite: false,
+    worldUnits: false,
+  });
+
+  const geometries: LineGeometry[] = [];
+
+  for (const ring of rings) {
+    if (ring.length < 2) continue;
+    const local = ring.map(([lon, lat]) => proj.lonLatToLocal(lon, lat));
+    const pts: number[] = [];
+    const push = (x: number, z: number) => {
+      pts.push(x, sampleGround(x, z) + DRAPE_OFFSET_M, z);
+    };
+
+    for (let i = 0; i < local.length; i++) {
+      const [x0, z0] = local[i];
+      const [x1, z1] = local[(i + 1) % local.length];
+      const len = Math.hypot(x1 - x0, z1 - z0);
+      const n = Math.max(1, Math.ceil(len / step));
+      for (let s = 0; s < n; s++) {
+        const t = s / n;
+        push(x0 + (x1 - x0) * t, z0 + (z1 - z0) * t);
+      }
+    }
+    push(local[0][0], local[0][1]);
+    if (pts.length < 6) continue;
+
+    const geometry = new LineGeometry();
+    geometry.setPositions(pts);
+    geometries.push(geometry);
+
+    const haloLine = new Line2(geometry, halo);
+    haloLine.computeLineDistances();
+    haloLine.renderOrder = 22;
+    group.add(haloLine);
+
+    const coreLine = new Line2(geometry, core);
+    coreLine.computeLineDistances();
+    coreLine.renderOrder = 23;
+    group.add(coreLine);
+  }
+
+  if (group.children.length === 0) return null;
+
+  return {
+    group,
+    setResolution: (w: number, h: number) => {
+      core.resolution.set(w, h);
+      halo.resolution.set(w, h);
+    },
+    dispose: () => {
+      geometries.forEach((g) => g.dispose());
+      core.dispose();
+      halo.dispose();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Implements Task W2 from the Impact Decision-Support Roadmap (docs/roadmap-Impact Decision-Support.md):
- Implements LocalAuthorityOutline module in apps/web/src/scene/ to drape local authority sub-boundaries on 3D terrain.
- Adds localAuthorities layer toggle, static layer descriptor, and legend entry with DLA/GISTDA attribution.
- Adds topology QA validation and ring cleaning utilities in apps/etl/src/buildLocalAuthorities.ts.
- Adds Thai and English localization catalog entries for the local authority layer.

## Visual Verification
![w2-local-authorities](https://github.com/flukelaster/SIAHRA/releases/download/primg-feat-local-authority-boundaries/w2-local-authorities.png)

## Verification
- oxlint src worker in apps/web: 0 errors.
- tsc across all workspaces: 0 type errors.
- Vitest suites (apps/api, apps/web, apps/etl): all 55 test files (532 tests) passing.
- Production build & Wrangler dry-run: passed without regressions.