### PR TITLE
feat(api): add deterministic threshold engine and AlertEngineDO (W5)

### DIFF
--- a/apps/api/src/data/thresholdRules.test.ts
+++ b/apps/api/src/data/thresholdRules.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ThresholdCondition, ThresholdRule } from "@siahra/shared-types";
+import { evaluateCondition, evaluateRule, THRESHOLD_RULES } from "./thresholdRules.js";
+
+describe("thresholdRules module", () => {
+  const sampleCondition: ThresholdCondition = {
+    parameter: "water_level_msl",
+    operator: ">=",
+    triggerValue: 4.0,
+    clearValue: 3.5,
+  };
+
+  it("triggers when condition exceeds triggerValue (inactive state)", () => {
+    expect(evaluateCondition(sampleCondition, 3.9, false)).toBe(false);
+    expect(evaluateCondition(sampleCondition, 4.0, false)).toBe(true);
+    expect(evaluateCondition(sampleCondition, 4.2, false)).toBe(true);
+  });
+
+  it("maintains active state until falling below hysteresis clearValue", () => {
+    // When currently triggered, 3.8 is still active (since clear is 3.5)
+    expect(evaluateCondition(sampleCondition, 3.8, true)).toBe(true);
+    expect(evaluateCondition(sampleCondition, 3.6, true)).toBe(true);
+    // Once below 3.5, it clears
+    expect(evaluateCondition(sampleCondition, 3.4, true)).toBe(false);
+  });
+
+  it("handles null or non-finite telemetry safely", () => {
+    expect(evaluateCondition(sampleCondition, null, false)).toBe(false);
+    expect(evaluateCondition(sampleCondition, NaN, false)).toBe(false);
+    expect(evaluateCondition(sampleCondition, Infinity, false)).toBe(false);
+  });
+
+  it("evaluates a full rule and generates AlertEvents for affected local authorities", () => {
+    const rule: ThresholdRule = THRESHOLD_RULES.find((r) => r.id === "RULE-90-01-WARN")!;
+    expect(rule).toBeDefined();
+
+    const telemetry = {
+      water_level_msl: 4.5,
+    };
+
+    const events = evaluateRule(rule, telemetry, new Set(), "2026-08-22T15:00:00Z");
+    expect(events.length).toBe(rule.affectedLocalAuthorityIds.length);
+    expect(events[0].ruleId).toBe("RULE-90-01-WARN");
+    expect(events[0].severity).toBe("warning");
+    expect(events[0].localAuthorityId).toBe("TH-LAO-901101");
+    expect(events[0].reasonTh).toContain("คลองอู่ตะเภา");
+  });
+});

--- a/apps/api/src/data/thresholdRules.ts
+++ b/apps/api/src/data/thresholdRules.ts
@@ -1,0 +1,235 @@
+import type { AlertEvent, ThresholdCondition, ThresholdRule } from "@siahra/shared-types";
+import { LOCAL_AUTHORITIES } from "./localAuthorities.js";
+
+/**
+ * Curated Deterministic Threshold Rules linking Telemetry Stations to Local Authorities.
+ */
+export const THRESHOLD_RULES: readonly ThresholdRule[] = [
+  // ── Hat Yai / Songkhla (U-Tapao Basin) ──────────────────────────────────
+  {
+    id: "RULE-90-01-WARN",
+    name: "ระดับน้ำคลองอู่ตะเภาเตือนภัย เทศบาลนครหาดใหญ่",
+    stationId: 9001,
+    stationKind: "waterlevel",
+    basinCode: "BASIN-SOUTHERN-EAST-01",
+    affectedLocalAuthorityIds: ["TH-LAO-901101", "TH-LAO-901102", "TH-LAO-901103"],
+    severity: "warning",
+    conditions: [
+      {
+        parameter: "water_level_msl",
+        operator: ">=",
+        triggerValue: 4.2,
+        clearValue: 3.8,
+      },
+    ],
+    minimumDurationMinutes: 15,
+    cooldownMinutes: 60,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+  {
+    id: "RULE-90-01-SEV",
+    name: "ระดับน้ำคลองอู่ตะเภาล้นตลิ่งวิกฤต เทศบาลนครหาดใหญ่",
+    stationId: 9001,
+    stationKind: "waterlevel",
+    basinCode: "BASIN-SOUTHERN-EAST-01",
+    affectedLocalAuthorityIds: ["TH-LAO-901101", "TH-LAO-901102", "TH-LAO-901103"],
+    severity: "severe",
+    conditions: [
+      {
+        parameter: "water_level_msl",
+        operator: ">=",
+        triggerValue: 5.0,
+        clearValue: 4.5,
+      },
+    ],
+    minimumDurationMinutes: 15,
+    cooldownMinutes: 60,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+  {
+    id: "RULE-90-RAIN-WARN",
+    name: "ฝนสะสม 24 ชม. หนักมาก ลุ่มน้ำคลองอู่ตะเภา",
+    stationId: 9010,
+    stationKind: "rainfall",
+    basinCode: "BASIN-SOUTHERN-EAST-01",
+    affectedLocalAuthorityIds: ["TH-LAO-901101", "TH-LAO-901104"],
+    severity: "warning",
+    conditions: [
+      {
+        parameter: "rain_24h_mm",
+        operator: ">=",
+        triggerValue: 90.0,
+        clearValue: 70.0,
+      },
+    ],
+    minimumDurationMinutes: 30,
+    cooldownMinutes: 120,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+  // ── Chiang Mai (Ping Basin - Station P.1) ──────────────────────────────
+  {
+    id: "RULE-50-01-WARN",
+    name: "ระดับน้ำแม่น้ำปิงสะพานนวรัฐเตือนภัย เทศบาลนครเชียงใหม่",
+    stationId: 5001,
+    stationKind: "waterlevel",
+    basinCode: "BASIN-PING-01",
+    affectedLocalAuthorityIds: ["TH-LAO-500101"],
+    severity: "warning",
+    conditions: [
+      {
+        parameter: "water_level_msl",
+        operator: ">=",
+        triggerValue: 3.7,
+        clearValue: 3.5,
+      },
+    ],
+    minimumDurationMinutes: 15,
+    cooldownMinutes: 60,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+  {
+    id: "RULE-50-01-SEV",
+    name: "ระดับน้ำแม่น้ำปิงสะพานนวรัฐวิกฤต เทศบาลนครเชียงใหม่",
+    stationId: 5001,
+    stationKind: "waterlevel",
+    basinCode: "BASIN-PING-01",
+    affectedLocalAuthorityIds: ["TH-LAO-500101"],
+    severity: "severe",
+    conditions: [
+      {
+        parameter: "water_level_msl",
+        operator: ">=",
+        triggerValue: 4.2,
+        clearValue: 3.9,
+      },
+    ],
+    minimumDurationMinutes: 15,
+    cooldownMinutes: 60,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+  // ── Nakhon Ratchasima (Lam Takhong Basin) ──────────────────────────────
+  {
+    id: "RULE-30-01-WARN",
+    name: "ระดับน้ำลำตะคองเตือนภัย เทศบาลนครนครราชสีมา",
+    stationId: 3001,
+    stationKind: "waterlevel",
+    basinCode: "BASIN-MUN-01",
+    affectedLocalAuthorityIds: ["TH-LAO-300101", "TH-LAO-300102"],
+    severity: "warning",
+    conditions: [
+      {
+        parameter: "water_level_msl",
+        operator: ">=",
+        triggerValue: 3.5,
+        clearValue: 3.2,
+      },
+    ],
+    minimumDurationMinutes: 15,
+    cooldownMinutes: 60,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+  // ── Ubon Ratchathani (Mun Basin - Station M.7) ──────────────────────────
+  {
+    id: "RULE-34-01-WARN",
+    name: "ระดับน้ำแม่น้ำมูลสะพานเสรีประชาธิปไตยเตือนภัย เทศบาลนครอุบลราชธานี",
+    stationId: 3401,
+    stationKind: "waterlevel",
+    basinCode: "BASIN-MUN-04",
+    affectedLocalAuthorityIds: ["TH-LAO-340101", "TH-LAO-341501"],
+    severity: "warning",
+    conditions: [
+      {
+        parameter: "water_level_msl",
+        operator: ">=",
+        triggerValue: 112.0,
+        clearValue: 111.5,
+      },
+    ],
+    minimumDurationMinutes: 15,
+    cooldownMinutes: 60,
+    sourceId: "thaiwater",
+    version: "2026.1",
+  },
+];
+
+const LAO_BY_ID = new Map(LOCAL_AUTHORITIES.map((l) => [l.id, l]));
+
+/**
+ * Checks if a numerical telemetry value triggers a threshold condition.
+ */
+export function evaluateCondition(
+  condition: ThresholdCondition,
+  currentValue: number | null,
+  isCurrentlyTriggered: boolean,
+): boolean {
+  if (currentValue === null || !Number.isFinite(currentValue)) {
+    return false;
+  }
+
+  // Use hysteresis clear threshold if currently active
+  const threshold = isCurrentlyTriggered ? condition.clearValue : condition.triggerValue;
+
+  switch (condition.operator) {
+    case ">":
+      return currentValue > threshold;
+    case ">=":
+      return currentValue >= threshold;
+    case "<":
+      return currentValue < threshold;
+    case "<=":
+      return currentValue <= threshold;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Evaluates a threshold rule against telemetry input readings.
+ */
+export function evaluateRule(
+  rule: ThresholdRule,
+  telemetry: Record<string, number | null>,
+  activeRuleIds: Set<string>,
+  nowIso: string,
+): AlertEvent[] {
+  const isCurrentlyActive = activeRuleIds.has(rule.id);
+
+  // All conditions must be satisfied
+  const allSatisfied = rule.conditions.every((cond) => {
+    const val = telemetry[cond.parameter] ?? null;
+    return evaluateCondition(cond, val, isCurrentlyActive);
+  });
+
+  if (!allSatisfied) {
+    return [];
+  }
+
+  // Generate an AlertEvent for each affected local authority
+  return rule.affectedLocalAuthorityIds.map((laoId) => {
+    const lao = LAO_BY_ID.get(laoId);
+    const provinceCode = lao ? lao.provinceCode : "10";
+
+    const reasonTh = `เกณฑ์ ${rule.name}: ตรวจพบค่าเกินเกณฑ์เตือนภัย (รหัสสถานี ${rule.stationId})`;
+    const reasonEn = `Rule ${rule.name}: Threshold exceeded at station #${rule.stationId}`;
+
+    return {
+      id: `ALERT-${rule.id}-${laoId}`,
+      ruleId: rule.id,
+      ruleVersion: rule.version,
+      localAuthorityId: laoId,
+      provinceCode,
+      severity: rule.severity,
+      triggeredAt: nowIso,
+      clearedAt: null,
+      reasonTh,
+      reasonEn,
+      inputSnapshot: { ...telemetry },
+    };
+  });
+}

--- a/apps/api/src/durable-objects/alert-engine.ts
+++ b/apps/api/src/durable-objects/alert-engine.ts
@@ -1,0 +1,253 @@
+import { DurableObject } from "cloudflare:workers";
+import type {
+  ActiveAlertsResponse,
+  AlertEvent,
+  ThresholdRule,
+  ThresholdRulesResponse,
+} from "@siahra/shared-types";
+import { evaluateRule, THRESHOLD_RULES } from "../data/thresholdRules.js";
+
+interface AlertRow extends Record<string, SqlStorageValue> {
+  id: string;
+  rule_id: string;
+  rule_version: string;
+  local_authority_id: string;
+  province_code: string;
+  severity: string;
+  triggered_at: string;
+  reason_th: string;
+  reason_en: string;
+  input_snapshot: string;
+  acknowledged_by: string | null;
+  acknowledged_at: string | null;
+}
+
+interface MetaRow extends Record<string, SqlStorageValue> {
+  value: string;
+}
+
+export class AlertEngineDO extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    ctx.blockConcurrencyWhile(async () => {
+      ctx.storage.sql.exec(`
+        CREATE TABLE IF NOT EXISTS active_alerts (
+          id TEXT PRIMARY KEY,
+          rule_id TEXT NOT NULL,
+          rule_version TEXT NOT NULL,
+          local_authority_id TEXT NOT NULL,
+          province_code TEXT NOT NULL,
+          severity TEXT NOT NULL,
+          triggered_at TEXT NOT NULL,
+          reason_th TEXT NOT NULL,
+          reason_en TEXT NOT NULL,
+          input_snapshot TEXT NOT NULL,
+          acknowledged_by TEXT,
+          acknowledged_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_active_province ON active_alerts(province_code);
+        CREATE INDEX IF NOT EXISTS idx_active_lao ON active_alerts(local_authority_id);
+
+        CREATE TABLE IF NOT EXISTS alert_audit_log (
+          id TEXT PRIMARY KEY,
+          alert_id TEXT NOT NULL,
+          rule_id TEXT NOT NULL,
+          local_authority_id TEXT NOT NULL,
+          province_code TEXT NOT NULL,
+          severity TEXT NOT NULL,
+          triggered_at TEXT NOT NULL,
+          cleared_at TEXT,
+          reason_th TEXT NOT NULL,
+          reason_en TEXT NOT NULL,
+          input_snapshot TEXT NOT NULL,
+          acknowledged_by TEXT,
+          acknowledged_at TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      `);
+    });
+  }
+
+  private readMeta(key: string): string | null {
+    return (
+      this.ctx.storage.sql.exec<MetaRow>("SELECT value FROM meta WHERE key = ?", key).toArray()[0]
+        ?.value ?? null
+    );
+  }
+
+  private writeMeta(key: string, value: string | null): void {
+    if (value === null) this.ctx.storage.sql.exec("DELETE FROM meta WHERE key = ?", key);
+    else
+      this.ctx.storage.sql.exec(
+        "INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        key,
+        value,
+      );
+  }
+
+  private rowToAlert(row: AlertRow): AlertEvent {
+    return {
+      id: row.id,
+      ruleId: row.rule_id,
+      ruleVersion: row.rule_version,
+      localAuthorityId: row.local_authority_id,
+      provinceCode: row.province_code,
+      severity: row.severity as AlertEvent["severity"],
+      triggeredAt: row.triggered_at,
+      clearedAt: null,
+      reasonTh: row.reason_th,
+      reasonEn: row.reason_en,
+      inputSnapshot: JSON.parse(row.input_snapshot) as Record<string, number | null>,
+      acknowledgedBy: row.acknowledged_by ?? undefined,
+      acknowledgedAt: row.acknowledged_at ?? undefined,
+    };
+  }
+
+  /**
+   * Evaluates station telemetry readings against all threshold rules deterministically.
+   */
+  async evaluateTelemetry(
+    stationReadings: Array<{ stationId: number; telemetry: Record<string, number | null> }>,
+    nowIso = new Date().toISOString(),
+  ): Promise<ActiveAlertsResponse> {
+    const readingMap = new Map<number, Record<string, number | null>>(
+      stationReadings.map((r) => [r.stationId, r.telemetry]),
+    );
+
+    // Get currently active rule IDs
+    const currentRows = this.ctx.storage.sql.exec<AlertRow>("SELECT * FROM active_alerts").toArray();
+    const activeRuleIds = new Set<string>(currentRows.map((r) => r.rule_id));
+
+    const newlyTriggered: AlertEvent[] = [];
+    const activeRuleIdsAfterEval = new Set<string>();
+
+    for (const rule of THRESHOLD_RULES) {
+      const telemetry = readingMap.get(rule.stationId);
+      if (!telemetry) continue;
+
+      const events = evaluateRule(rule, telemetry, activeRuleIds, nowIso);
+      if (events.length > 0) {
+        newlyTriggered.push(...events);
+        activeRuleIdsAfterEval.add(rule.id);
+      }
+    }
+
+    // Identify cleared rules that were active before but not in newlyTriggered
+    for (const oldRow of currentRows) {
+      if (!activeRuleIdsAfterEval.has(oldRow.rule_id)) {
+        // Rule has cleared due to hysteresis!
+        // Record in audit log
+        this.ctx.storage.sql.exec(
+          `INSERT INTO alert_audit_log (
+            id, alert_id, rule_id, local_authority_id, province_code, severity,
+            triggered_at, cleared_at, reason_th, reason_en, input_snapshot, acknowledged_by, acknowledged_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `AUDIT-${oldRow.id}-${Date.now()}`,
+          oldRow.id,
+          oldRow.rule_id,
+          oldRow.local_authority_id,
+          oldRow.province_code,
+          oldRow.severity,
+          oldRow.triggered_at,
+          nowIso,
+          oldRow.reason_th,
+          oldRow.reason_en,
+          oldRow.input_snapshot,
+          oldRow.acknowledged_by,
+          oldRow.acknowledged_at,
+        );
+
+        // Delete from active_alerts
+        this.ctx.storage.sql.exec("DELETE FROM active_alerts WHERE id = ?", oldRow.id);
+      }
+    }
+
+    // Insert or update newly triggered active alerts
+    for (const ev of newlyTriggered) {
+      this.ctx.storage.sql.exec(
+        `INSERT INTO active_alerts (
+          id, rule_id, rule_version, local_authority_id, province_code, severity,
+          triggered_at, reason_th, reason_en, input_snapshot
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          severity = excluded.severity,
+          input_snapshot = excluded.input_snapshot`,
+        ev.id,
+        ev.ruleId,
+        ev.ruleVersion,
+        ev.localAuthorityId,
+        ev.provinceCode,
+        ev.severity,
+        ev.triggeredAt,
+        ev.reasonTh,
+        ev.reasonEn,
+        JSON.stringify(ev.inputSnapshot),
+      );
+    }
+
+    this.writeMeta("lastEvaluatedAt", nowIso);
+    return this.getActiveAlerts();
+  }
+
+  /**
+   * Retrieves active alert events with optional filtering.
+   */
+  async getActiveAlerts(filter?: {
+    provinceCode?: string;
+    localAuthorityId?: string;
+  }): Promise<ActiveAlertsResponse> {
+    let query = "SELECT * FROM active_alerts";
+    const params: SqlStorageValue[] = [];
+
+    if (filter?.provinceCode) {
+      query += " WHERE province_code = ?";
+      params.push(filter.provinceCode);
+    } else if (filter?.localAuthorityId) {
+      query += " WHERE local_authority_id = ?";
+      params.push(filter.localAuthorityId);
+    }
+
+    const rows = this.ctx.storage.sql.exec<AlertRow>(query, ...params).toArray();
+    const evaluatedAt = this.readMeta("lastEvaluatedAt") ?? new Date().toISOString();
+
+    return {
+      total: rows.length,
+      evaluatedAt,
+      alerts: rows.map((r) => this.rowToAlert(r)),
+    };
+  }
+
+  /**
+   * Retrieves threshold rules.
+   */
+  async getRules(filter?: { stationId?: number; basinCode?: string }): Promise<ThresholdRulesResponse> {
+    let rules: ThresholdRule[] = [...THRESHOLD_RULES];
+
+    if (filter?.stationId) {
+      rules = rules.filter((r) => r.stationId === filter.stationId);
+    }
+    if (filter?.basinCode) {
+      rules = rules.filter((r) => r.basinCode === filter.basinCode);
+    }
+
+    return {
+      total: rules.length,
+      rules,
+    };
+  }
+
+  /**
+   * Acknowledges an active alert.
+   */
+  async acknowledgeAlert(alertId: string, author: string): Promise<boolean> {
+    const nowIso = new Date().toISOString();
+    const res = this.ctx.storage.sql.exec(
+      "UPDATE active_alerts SET acknowledged_by = ?, acknowledged_at = ? WHERE id = ?",
+      author,
+      nowIso,
+      alertId,
+    );
+    return res.rowsWritten > 0;
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,8 +16,14 @@ import {
   handleLocalAuthorityExposure,
   handleLocalAuthorityImpact,
 } from "./routes/localAuthorities.js";
+import {
+  handleActiveAlerts,
+  handleAlertRules,
+  handleEvaluateAlerts,
+} from "./routes/alerts.js";
 import type { AppEnv } from "./types.js";
 
+export { AlertEngineDO } from "./durable-objects/alert-engine.js";
 export { EarthquakeFeedDO } from "./durable-objects/earthquake-feed.js";
 export { FloodExtentDO } from "./durable-objects/flood-extent.js";
 export { ForecastPointerDO } from "./durable-objects/forecast-pointer.js";
@@ -113,6 +119,24 @@ export const routes: Route[] = [
     pattern: /^\/api\/v1\/local-authorities\/([A-Za-z0-9_-]+)$/,
     handler: (_req, env, [id]) => handleLocalAuthorityDetail(id, env),
     limit: { perMinute: 300 },
+  },
+  {
+    method: "GET",
+    pattern: /^\/api\/v1\/alerts\/active$/,
+    handler: (req, env) => handleActiveAlerts(req, env),
+    limit: { perMinute: 300 },
+  },
+  {
+    method: "GET",
+    pattern: /^\/api\/v1\/alerts\/rules$/,
+    handler: (req, env) => handleAlertRules(req, env),
+    limit: { perMinute: 300 },
+  },
+  {
+    method: "POST",
+    pattern: /^\/api\/v1\/alerts\/evaluate$/,
+    handler: (req, env) => handleEvaluateAlerts(req, env),
+    limit: { perMinute: 60 },
   },
 ];
 

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -1,0 +1,79 @@
+import { isProvinceCode } from "@siahra/shared-types";
+import { json } from "../router.js";
+import type { AppEnv } from "../types.js";
+import * as cachePolicy from "../cachePolicy.js";
+
+/**
+ * GET /api/v1/alerts/active[?province=NN][&localAuthorityId=ID]
+ */
+export async function handleActiveAlerts(req: Request, env: AppEnv): Promise<Response> {
+  const url = new URL(req.url);
+  const province = url.searchParams.get("province");
+  const localAuthorityId = url.searchParams.get("localAuthorityId") || undefined;
+
+  if (province !== null && !isProvinceCode(province)) {
+    return json({ error: `Invalid province code "${province}"` }, { status: 400 });
+  }
+
+  const stub = env.ALERT_ENGINE.getByName("primary");
+  const data = await stub.getActiveAlerts({
+    provinceCode: province ?? undefined,
+    localAuthorityId,
+  });
+
+  return json(data, {
+    cache: cachePolicy.realtime,
+  });
+}
+
+/**
+ * GET /api/v1/alerts/rules[?stationId=ID][&basin=CODE]
+ */
+export async function handleAlertRules(req: Request, env: AppEnv): Promise<Response> {
+  const url = new URL(req.url);
+  const stationIdParam = url.searchParams.get("stationId");
+  const basinCode = url.searchParams.get("basin") || undefined;
+
+  let stationId: number | undefined;
+  if (stationIdParam !== null) {
+    stationId = Number(stationIdParam);
+    if (!Number.isFinite(stationId)) {
+      return json({ error: `Invalid stationId "${stationIdParam}"` }, { status: 400 });
+    }
+  }
+
+  const stub = env.ALERT_ENGINE.getByName("primary");
+  const data = await stub.getRules({
+    stationId,
+    basinCode,
+  });
+
+  return json(data, {
+    cache: cachePolicy.slowMoving,
+  });
+}
+
+/**
+ * POST /api/v1/alerts/evaluate
+ */
+export async function handleEvaluateAlerts(req: Request, env: AppEnv): Promise<Response> {
+  let readings: Array<{ stationId: number; telemetry: Record<string, number | null> }> = [];
+
+  try {
+    const body = (await req.json()) as {
+      readings?: Array<{ stationId: number; telemetry: Record<string, number | null> }>;
+    };
+    if (Array.isArray(body?.readings)) {
+      readings = body.readings;
+    }
+  } catch {
+    // If empty body, proceed with empty readings
+  }
+
+  const stub = env.ALERT_ENGINE.getByName("primary");
+  const result = await stub.evaluateTelemetry(readings);
+
+  return json(result, {
+    cache: cachePolicy.noStore,
+  });
+}

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,3 +1,4 @@
+import type { AlertEngineDO } from "./durable-objects/alert-engine.js";
 import type { EarthquakeFeedDO } from "./durable-objects/earthquake-feed.js";
 import type { FloodExtentDO } from "./durable-objects/flood-extent.js";
 import type { ForecastPointerDO } from "./durable-objects/forecast-pointer.js";
@@ -7,15 +8,24 @@ import type { RadarDO } from "./durable-objects/radar.js";
 /**
  * `wrangler types` leaves DurableObjectNamespace bindings untyped (see the
  * `/* ClassName *\/` comment it emits) because it can't infer the RPC surface
- * automatically. This re-declares the two DO bindings with their concrete
+ * automatically. This re-declares the DO bindings with their concrete
  * class so `.getByName(...).someMethod()` type-checks; every other binding
  * is passed through unchanged from the generated ambient `Env`.
  */
 export interface AppEnv
-  extends Omit<Env, "EARTHQUAKE_FEED" | "FORECAST_POINTER" | "OBSERVATION_CACHE" | "FLOOD_EXTENT" | "RADAR"> {
+  extends Omit<
+    Env,
+    | "EARTHQUAKE_FEED"
+    | "FORECAST_POINTER"
+    | "OBSERVATION_CACHE"
+    | "FLOOD_EXTENT"
+    | "RADAR"
+    | "ALERT_ENGINE"
+  > {
   RADAR: DurableObjectNamespace<RadarDO>;
   EARTHQUAKE_FEED: DurableObjectNamespace<EarthquakeFeedDO>;
   FLOOD_EXTENT: DurableObjectNamespace<FloodExtentDO>;
   FORECAST_POINTER: DurableObjectNamespace<ForecastPointerDO>;
   OBSERVATION_CACHE: DurableObjectNamespace<ObservationCacheDO>;
+  ALERT_ENGINE: DurableObjectNamespace<AlertEngineDO>;
 }

--- a/apps/api/test/alerts.test.ts
+++ b/apps/api/test/alerts.test.ts
@@ -1,0 +1,88 @@
+import { exports as workerExports } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import type { ActiveAlertsResponse, ThresholdRulesResponse } from "@siahra/shared-types";
+
+const workerFetch = (url: string, init: RequestInit = {}) =>
+  workerExports.default.fetch(new Request(url, init));
+
+describe("Alerts and Threshold Endpoints", () => {
+  it("GET /api/v1/alerts/rules returns configured threshold rules", async () => {
+    const res = await workerFetch("https://siahra-radar.co/api/v1/alerts/rules");
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as ThresholdRulesResponse;
+    expect(data.total).toBeGreaterThan(0);
+    expect(Array.isArray(data.rules)).toBe(true);
+    expect(data.rules.some((r) => r.id === "RULE-90-01-WARN")).toBe(true);
+  });
+
+  it("GET /api/v1/alerts/rules?stationId=9001 filters by station", async () => {
+    const res = await workerFetch("https://siahra-radar.co/api/v1/alerts/rules?stationId=9001");
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as ThresholdRulesResponse;
+    expect(data.total).toBeGreaterThan(0);
+    expect(data.rules.every((r) => r.stationId === 9001)).toBe(true);
+  });
+
+  it("POST /api/v1/alerts/evaluate evaluates telemetry and records active alerts in DO", async () => {
+    const res = await workerFetch("https://siahra-radar.co/api/v1/alerts/evaluate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        readings: [
+          {
+            stationId: 9001,
+            telemetry: {
+              water_level_msl: 4.8, // Exceeds RULE-90-01-WARN (>= 4.2)
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ActiveAlertsResponse;
+    expect(data.total).toBeGreaterThan(0);
+    expect(data.alerts.some((a) => a.ruleId === "RULE-90-01-WARN")).toBe(true);
+  });
+
+  it("GET /api/v1/alerts/active returns current active alerts", async () => {
+    const res = await workerFetch("https://siahra-radar.co/api/v1/alerts/active");
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as ActiveAlertsResponse;
+    expect(data.evaluatedAt).toBeDefined();
+    expect(Array.isArray(data.alerts)).toBe(true);
+  });
+
+  it("GET /api/v1/alerts/active?province=90 filters by province code", async () => {
+    const res = await workerFetch("https://siahra-radar.co/api/v1/alerts/active?province=90");
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as ActiveAlertsResponse;
+    expect(data.alerts.every((a) => a.provinceCode === "90")).toBe(true);
+  });
+
+  it("POST /api/v1/alerts/evaluate clears alerts when telemetry falls below hysteresis clearValue", async () => {
+    // When station water level drops below clearValue (3.8) e.g. to 3.2
+    const res = await workerFetch("https://siahra-radar.co/api/v1/alerts/evaluate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        readings: [
+          {
+            stationId: 9001,
+            telemetry: {
+              water_level_msl: 3.2,
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ActiveAlertsResponse;
+    expect(data.alerts.some((a) => a.ruleId === "RULE-90-01-WARN")).toBe(false);
+  });
+});

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -45,14 +45,16 @@
       { "name": "FORECAST_POINTER", "class_name": "ForecastPointerDO" },
       { "name": "OBSERVATION_CACHE", "class_name": "ObservationCacheDO" },
       { "name": "FLOOD_EXTENT", "class_name": "FloodExtentDO" },
-      { "name": "RADAR", "class_name": "RadarDO" }
+      { "name": "RADAR", "class_name": "RadarDO" },
+      { "name": "ALERT_ENGINE", "class_name": "AlertEngineDO" }
     ]
   },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["EarthquakeFeedDO", "ForecastPointerDO"] },
     { "tag": "v2", "new_sqlite_classes": ["ObservationCacheDO"] },
     { "tag": "v3", "new_sqlite_classes": ["FloodExtentDO"] },
-    { "tag": "v4", "new_sqlite_classes": ["RadarDO"] }
+    { "tag": "v4", "new_sqlite_classes": ["RadarDO"] },
+    { "tag": "v5", "new_sqlite_classes": ["AlertEngineDO"] }
   ],
 
   "triggers": { "crons": ["* * * * *"] },

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,9 @@ edit in that table.
 | `/api/v1/local-authorities/impact` | GET | 300 | default | per route | Live observed impact summary for local authorities in a province |
 | `/api/v1/local-authorities/{id}/impact` | GET | 300 | default | per route | Live observed impact detail for a specific local authority |
 | `/api/v1/local-authorities/{id}` | GET | 300 | default | per route | Local authority detail by canonical ID or DLA code |
+| `/api/v1/alerts/active` | GET | 300 | default | per route | Query currently active alert events (with DO persistence) |
+| `/api/v1/alerts/rules` | GET | 300 | default | per route | List configured deterministic threshold rules |
+| `/api/v1/alerts/evaluate` | POST | 60 | default | per route | Deterministic evaluation of telemetry against threshold rules |
 
 A rejected request answers `429 {"error":"Too many requests","retryAfterSeconds":N}` plus
 `Retry-After: N`. `/api/v1/health` reports how many 429s this isolate issued in the last hour under
@@ -95,6 +98,9 @@ Two rules are enforced by `json()` in `apps/api/src/router.ts` rather than by ea
 | `/api/v1/local-authorities/impact` | `floodExtent(retrievedAt)` | `public, max-age=300, s-maxage=600`, or `no-store` when nothing has ever been retrieved |
 | `/api/v1/local-authorities/{id}/impact` | `floodExtent(retrievedAt)` | as above |
 | `/api/v1/local-authorities/{id}` | `slowMoving` | `public, max-age=300` |
+| `/api/v1/alerts/active` | `realtime` | `public, max-age=10, s-maxage=20` |
+| `/api/v1/alerts/rules` | `slowMoving` | `public, max-age=300` |
+| `/api/v1/alerts/evaluate` | `noStore` | `no-store` |
 | any 4xx / 5xx | `noStore` | `no-store` |
 
 `stale-while-revalidate` was considered for the observations response (roadmap E4.6 sketches it) and

--- a/packages/shared-types/src/threshold.ts
+++ b/packages/shared-types/src/threshold.ts
@@ -45,6 +45,7 @@ export interface AlertEvent {
   ruleId: string;
   ruleVersion: string;
   localAuthorityId: string;
+  provinceCode: string;
   severity: ThresholdSeverity;
   triggeredAt: string;
   clearedAt: string | null;
@@ -53,4 +54,21 @@ export interface AlertEvent {
   inputSnapshot: Record<string, number | null>;
   acknowledgedBy?: string;
   acknowledgedAt?: string;
+}
+
+/**
+ * Response envelope for active alerts query endpoint.
+ */
+export interface ActiveAlertsResponse {
+  total: number;
+  evaluatedAt: string;
+  alerts: AlertEvent[];
+}
+
+/**
+ * Response envelope for threshold rules query endpoint.
+ */
+export interface ThresholdRulesResponse {
+  total: number;
+  rules: ThresholdRule[];
 }


### PR DESCRIPTION
## Summary
Implements Task W5 from the Impact Decision-Support Roadmap (docs/roadmap-Impact Decision-Support.md):
- Implements AlertEngineDO Durable Object with SQLite persistence for active_alerts and alert_audit_log.
- Adds deterministic ThresholdRule definitions linking sensor stations to downstream Local Authorities (LAOs).
- Implements hysteresis threshold evaluation to prevent alert oscillation.
- Adds REST endpoints: GET /api/v1/alerts/active, GET /api/v1/alerts/rules, and POST /api/v1/alerts/evaluate.
- Documents endpoints in docs/api.md and adds comprehensive unit and integration test coverage.

## Verification
- oxlint src worker in apps/web: 0 errors.
- tsc across all workspaces: 0 type errors.
- Vitest suites (apps/api, apps/web, apps/etl): all 56 test files (545 tests) passing.
- Production build & Wrangler dry-run: passed without regressions.