### PR TITLE
feat(web): add operational decision support UI and alert banner (W6)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,6 +28,8 @@ import { WaterLevelCard } from "./components/hazard/WaterLevelCard";
 import { RainfallCard } from "./components/hazard/RainfallCard";
 import { DamCard } from "./components/hazard/DamCard";
 import { EarthquakeLiveCard } from "./components/hazard/EarthquakeLiveCard";
+import { ActiveAlertBanner } from "./components/hazard/ActiveAlertBanner";
+import { useLocalAuthorityImpact } from "./hooks/useLocalAuthorityImpact";
 import { BRAND, DATA_ATTRIBUTION_TH } from "./branding";
 import type { CameraPose } from "./scene/setupScene";
 import type { QualityLevel, QualityMode } from "./scene/quality";
@@ -115,6 +117,8 @@ export default function App() {
   const dams = useDams(provinceCode);
   const radar = useRadar(layers.radar);
   const earthquakes = useEarthquakeFeed();
+  const [selectedLaoId, setSelectedLaoId] = useState<string | null>(null);
+  const decisionSupport = useLocalAuthorityImpact(provinceCode, selectedLaoId);
   const apiHealth = useApiHealth();
   const floodExtent = useFloodExtent(provinceCode);
   // ชั้นปิดอยู่ = ไม่ยิงคำขอเลยแม้แต่ครั้งเดียว (รูปแบบเดียวกับ useRadar)
@@ -355,6 +359,13 @@ export default function App() {
         compact={compact}
       />
 
+      <div className="absolute top-[68px] left-1/2 -translate-x-1/2 z-20 w-full max-w-xl px-4 pointer-events-none">
+        <ActiveAlertBanner
+          alerts={decisionSupport.activeAlerts}
+          onSelectLocalAuthority={setSelectedLaoId}
+        />
+      </div>
+
       {compact ? (
         <>
           <div
@@ -455,6 +466,9 @@ export default function App() {
             earthquakes={earthquakes}
             floodExtent={floodExtent}
             dams={dams}
+            decisionSupport={decisionSupport}
+            selectedLaoId={selectedLaoId}
+            onSelectLocalAuthority={setSelectedLaoId}
             atIso={atIso}
             width={RIGHT_W}
             top={dockTop}

--- a/apps/web/src/components/hazard/ActiveAlertBanner.tsx
+++ b/apps/web/src/components/hazard/ActiveAlertBanner.tsx
@@ -1,0 +1,45 @@
+import type { AlertEvent } from "@siahra/shared-types";
+import { useLang } from "../../i18n/context";
+
+interface ActiveAlertBannerProps {
+  alerts: readonly AlertEvent[];
+  onSelectLocalAuthority?: (laoId: string) => void;
+}
+
+export function ActiveAlertBanner({ alerts, onSelectLocalAuthority }: ActiveAlertBannerProps) {
+  const { lang } = useLang();
+
+  if (alerts.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5 w-full max-w-2xl mx-auto mb-2 pointer-events-auto">
+      {alerts.map((alert) => {
+        const isSevere = alert.severity === "severe";
+        const reason = lang === "th" ? alert.reasonTh : alert.reasonEn;
+
+        return (
+          <div
+            key={alert.id}
+            onClick={() => onSelectLocalAuthority?.(alert.localAuthorityId)}
+            className={`flex items-center justify-between gap-3 px-3 py-2 rounded-lg border backdrop-blur-md shadow-lg cursor-pointer transition-transform hover:scale-[1.01] ${
+              isSevere
+                ? "bg-rose-950/85 border-rose-500/60 text-rose-100"
+                : "bg-amber-950/85 border-amber-500/60 text-amber-100"
+            }`}
+          >
+            <div className="flex items-center gap-2.5 min-w-0">
+              <span className={`w-2.5 h-2.5 rounded-full animate-ping ${isSevere ? "bg-rose-400" : "bg-amber-400"}`} />
+              <span className="text-xs font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-black/40">
+                {alert.severity}
+              </span>
+              <p className="text-xs font-medium truncate">{reason}</p>
+            </div>
+            <span className="text-[10px] text-zinc-400 shrink-0 font-mono">
+              {new Date(alert.triggeredAt).toLocaleTimeString()}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/hazard/AffectedAuthorityList.tsx
+++ b/apps/web/src/components/hazard/AffectedAuthorityList.tsx
@@ -1,0 +1,64 @@
+import type { LocalAuthorityImpactResponse } from "@siahra/shared-types";
+import { useLang } from "../../i18n/context";
+
+interface AffectedAuthorityListProps {
+  impacts: readonly LocalAuthorityImpactResponse[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+export function AffectedAuthorityList({
+  impacts,
+  selectedId,
+  onSelect,
+}: AffectedAuthorityListProps) {
+  const { lang } = useLang();
+
+  if (impacts.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between text-xs font-semibold text-zinc-400 px-1">
+        <span>{lang === "th" ? "อันดับ อปท. ที่ได้รับผลกระทบ" : "Affected Local Authorities"}</span>
+        <span className="text-[10px] font-mono text-zinc-500">{impacts.length} อปท.</span>
+      </div>
+
+      <div className="flex flex-col gap-1.5 max-h-56 overflow-y-auto pr-1">
+        {impacts.map((item) => {
+          const isSelected = item.localAuthority.id === selectedId;
+          const name = lang === "th" ? item.localAuthority.nameTh : item.localAuthority.nameEn;
+
+          const badgeColor = {
+            severe: "bg-rose-500/20 text-rose-300 border-rose-500/40",
+            high: "bg-orange-500/20 text-orange-300 border-orange-500/40",
+            elevated: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+            low: "bg-zinc-800 text-zinc-400 border-zinc-700",
+          }[item.severity];
+
+          return (
+            <button
+              key={item.localAuthority.id}
+              onClick={() => onSelect(item.localAuthority.id)}
+              className={`flex items-center justify-between gap-2 p-2 rounded-lg text-left text-xs transition-colors border ${
+                isSelected
+                  ? "bg-zinc-800 border-cyan-500/60 text-white"
+                  : "bg-zinc-900/60 border-zinc-800/80 text-zinc-300 hover:bg-zinc-800/60"
+              }`}
+            >
+              <div className="flex flex-col min-w-0">
+                <span className="font-semibold truncate">{name}</span>
+                <span className="text-[10px] text-zinc-500">
+                  {item.exposure.populationExposed.toLocaleString()} {lang === "th" ? "คน" : "people"}
+                </span>
+              </div>
+
+              <span className={`text-[10px] uppercase font-bold px-1.5 py-0.5 rounded border shrink-0 ${badgeColor}`}>
+                {item.severity}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/hazard/ImpactSummaryCard.tsx
+++ b/apps/web/src/components/hazard/ImpactSummaryCard.tsx
@@ -1,0 +1,124 @@
+import type { LocalAuthorityImpactResponse } from "@siahra/shared-types";
+import { useLang } from "../../i18n/context";
+
+interface ImpactSummaryCardProps {
+  impact: LocalAuthorityImpactResponse | null;
+  onClose?: () => void;
+}
+
+export function ImpactSummaryCard({ impact, onClose }: ImpactSummaryCardProps) {
+  const { lang } = useLang();
+
+  if (!impact) return null;
+
+  const { localAuthority, exposure, severity, layer } = impact;
+  const name = lang === "th" ? localAuthority.nameTh : localAuthority.nameEn;
+
+  const severityColor = {
+    severe: "bg-rose-500/20 text-rose-300 border-rose-500/40",
+    high: "bg-orange-500/20 text-orange-300 border-orange-500/40",
+    elevated: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+    low: "bg-emerald-500/20 text-emerald-300 border-emerald-500/40",
+  }[severity];
+
+  const inundationPct =
+    exposure.populationTotal > 0
+      ? Math.round((exposure.populationExposed / exposure.populationTotal) * 100)
+      : 0;
+
+  return (
+    <div className="bg-zinc-900/90 border border-zinc-700/60 rounded-xl p-4 shadow-xl backdrop-blur-md text-zinc-100 flex flex-col gap-3">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2 border-b border-zinc-800 pb-2.5">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className={`text-[11px] font-semibold uppercase px-2 py-0.5 rounded border ${severityColor}`}>
+              {severity}
+            </span>
+            <span className="text-[11px] text-zinc-400 font-mono">DLA {localAuthority.dlaCode}</span>
+          </div>
+          <h3 className="text-base font-bold mt-1 text-white">{name}</h3>
+        </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="text-zinc-400 hover:text-zinc-200 text-lg leading-none p-1"
+            title="Close"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {/* Primary Metrics Grid */}
+      <div className="grid grid-cols-2 gap-2.5 text-xs">
+        <div className="bg-zinc-800/60 p-2.5 rounded-lg border border-zinc-700/40">
+          <span className="text-zinc-400 block text-[11px]">
+            {lang === "th" ? "ประชากรที่ได้รับผลกระทบ" : "Exposed Population"}
+          </span>
+          <span className="text-lg font-bold text-rose-400">
+            {exposure.populationExposed.toLocaleString()}
+          </span>
+          <span className="text-[10px] text-zinc-500 block">
+            / {exposure.populationTotal.toLocaleString()} ({inundationPct}%)
+          </span>
+        </div>
+
+        <div className="bg-zinc-800/60 p-2.5 rounded-lg border border-zinc-700/40">
+          <span className="text-zinc-400 block text-[11px]">
+            {lang === "th" ? "อาคารที่อยู่ในพื้นที่น้ำท่วม" : "Exposed Buildings"}
+          </span>
+          <span className="text-lg font-bold text-amber-400">
+            {exposure.buildingsExposed.toLocaleString()}
+          </span>
+          <span className="text-[10px] text-zinc-500 block">
+            / {exposure.buildingsTotal.toLocaleString()}
+          </span>
+        </div>
+      </div>
+
+      {/* Critical Facilities & Infrastructure */}
+      <div className="bg-zinc-800/40 p-2.5 rounded-lg border border-zinc-800 text-xs flex flex-col gap-1.5">
+        <span className="text-[11px] font-semibold text-zinc-300">
+          {lang === "th" ? "สถานบริการและโครงสร้างพื้นฐานวิกฤต" : "Critical Facilities"}
+        </span>
+        <div className="grid grid-cols-2 gap-2 text-[11px] text-zinc-300">
+          <div className="flex items-center justify-between">
+            <span>{lang === "th" ? "โรงพยาบาล/รพ.สต." : "Hospitals"}:</span>
+            <span className={exposure.criticalFacilities.hospitals > 0 ? "font-bold text-rose-400" : "text-zinc-500"}>
+              {exposure.criticalFacilities.hospitals}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>{lang === "th" ? "สถานศึกษา" : "Schools"}:</span>
+            <span className={exposure.criticalFacilities.schools > 0 ? "font-bold text-amber-400" : "text-zinc-500"}>
+              {exposure.criticalFacilities.schools}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>{lang === "th" ? "ถนนที่ท่วม (กม.)" : "Roads (km)"}:</span>
+            <span className="font-semibold text-zinc-200">{exposure.roadKmExposed} km</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>{lang === "th" ? "พื้นที่เกษตร (ไร่)" : "Agri (ha)"}:</span>
+            <span className="font-semibold text-zinc-200">{exposure.agriculturalHaExposed ?? 0} ha</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Epistemic / Data Honesty Footer */}
+      <div className="flex items-center justify-between pt-1 border-t border-zinc-800/80 text-[10px] text-zinc-400">
+        <div className="flex items-center gap-1.5">
+          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+          <span className="font-mono uppercase">{layer.epistemicClass}</span>
+          <span>(GISTDA + WorldPop + OSM)</span>
+        </div>
+        {layer.fetchedAt && (
+          <span className="font-mono text-zinc-500">
+            {new Date(layer.fetchedAt).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/RightPanel.tsx
+++ b/apps/web/src/components/layout/RightPanel.tsx
@@ -2,11 +2,14 @@ import type { EarthquakeFeedState } from "../../hooks/useEarthquakeFeed";
 import type { DamsState } from "../../hooks/useDams";
 import type { FloodExtentState } from "../../hooks/useFloodExtent";
 import type { ObservationsState } from "../../hooks/useObservations";
+import type { UseLocalAuthorityImpactResult } from "../../hooks/useLocalAuthorityImpact";
 import { EarthquakeLiveCard } from "../hazard/EarthquakeLiveCard";
 import { DamCard } from "../hazard/DamCard";
 import { FloodExtentCard } from "../hazard/FloodExtentCard";
 import { RainfallCard } from "../hazard/RainfallCard";
 import { WaterLevelCard } from "../hazard/WaterLevelCard";
+import { ImpactSummaryCard } from "../hazard/ImpactSummaryCard";
+import { AffectedAuthorityList } from "../hazard/AffectedAuthorityList";
 import { useT } from "../../i18n/context";
 import { resolveError } from "../../lib/errorMessage";
 
@@ -16,6 +19,9 @@ export function RightPanel({
   earthquakes,
   floodExtent,
   dams,
+  decisionSupport,
+  selectedLaoId,
+  onSelectLocalAuthority,
   atIso,
   width,
   top,
@@ -24,6 +30,9 @@ export function RightPanel({
   earthquakes: EarthquakeFeedState;
   floodExtent: FloodExtentState;
   dams: DamsState;
+  decisionSupport?: UseLocalAuthorityImpactResult;
+  selectedLaoId?: string | null;
+  onSelectLocalAuthority?: (id: string) => void;
   atIso: string | null;
   width: number;
   top: number;
@@ -47,6 +56,22 @@ export function RightPanel({
             <br />
             <span className="text-[var(--color-fg-muted)]">{t("common.reconnecting")}</span>
           </span>
+        </div>
+      ) : null}
+
+      {/* Decision Support: Local Authority Impact Summary */}
+      {decisionSupport?.selectedImpact ? (
+        <ImpactSummaryCard impact={decisionSupport.selectedImpact} />
+      ) : null}
+
+      {/* Decision Support: Affected Authorities Rankings */}
+      {decisionSupport && decisionSupport.impacts.length > 0 ? (
+        <div className="glass rounded-xl p-3">
+          <AffectedAuthorityList
+            impacts={decisionSupport.impacts}
+            selectedId={selectedLaoId ?? null}
+            onSelect={(id) => onSelectLocalAuthority?.(id)}
+          />
         </div>
       ) : null}
 

--- a/apps/web/src/hooks/useLocalAuthorityImpact.ts
+++ b/apps/web/src/hooks/useLocalAuthorityImpact.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import type { ActiveAlertsResponse, LocalAuthorityImpactResponse } from "@siahra/shared-types";
+
+export interface UseLocalAuthorityImpactResult {
+  impacts: LocalAuthorityImpactResponse[];
+  activeAlerts: ActiveAlertsResponse["alerts"];
+  selectedImpact: LocalAuthorityImpactResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useLocalAuthorityImpact(
+  provinceCode: string,
+  selectedLaoId: string | null,
+): UseLocalAuthorityImpactResult {
+  const [impacts, setImpacts] = useState<LocalAuthorityImpactResponse[]>([]);
+  const [activeAlerts, setActiveAlerts] = useState<ActiveAlertsResponse["alerts"]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    async function loadData() {
+      try {
+        const [impactRes, alertRes] = await Promise.all([
+          fetch(`/api/v1/local-authorities/impact?province=${provinceCode}`),
+          fetch(`/api/v1/alerts/active?province=${provinceCode}`),
+        ]);
+
+        if (cancelled) return;
+
+        if (impactRes.ok) {
+          const impactJson = (await impactRes.json()) as { impacts: LocalAuthorityImpactResponse[] };
+          setImpacts(impactJson.impacts ?? []);
+        }
+
+        if (alertRes.ok) {
+          const alertJson = (await alertRes.json()) as ActiveAlertsResponse;
+          setActiveAlerts(alertJson.alerts ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load decision-support data");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void loadData();
+
+    const interval = setInterval(() => {
+      setTick((t) => t + 1);
+    }, 60_000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [provinceCode, tick]);
+
+  const selectedImpact =
+    (selectedLaoId ? impacts.find((i) => i.localAuthority.id === selectedLaoId) : null) ??
+    impacts[0] ??
+    null;
+
+  return {
+    impacts,
+    activeAlerts,
+    selectedImpact,
+    isLoading,
+    error,
+    refetch: () => setTick((t) => t + 1),
+  };
+}


### PR DESCRIPTION
## Summary
Implements Task W6 from the Impact Decision-Support Roadmap (docs/roadmap-Impact Decision-Support.md), concluding the Phase 1 MVP Milestone:
- Introduces useLocalAuthorityImpact hook in apps/web/src/hooks/useLocalAuthorityImpact.ts for real-time impact and active alert polling.
- Implements ImpactSummaryCard component displaying severity tier, exposed population count, affected buildings, critical facilities, and data honesty attribution.
- Implements AffectedAuthorityList component ranking Local Authorities (LAOs) by severity and exposure in the province.
- Implements ActiveAlertBanner component for real-time deterministic warning banners.
- Integrates decision-support cards into RightPanel and App layout.

## Screenshots
![decision-support-ui](https://github.com/flukelaster/SIAHRA/releases/download/primg-feat-operational-decision-support-ui/decision-support-ui.png)

## Verification
- oxlint src worker in apps/web: 0 errors.
- tsc across all workspaces: 0 type errors.
- Vitest suites (apps/api, apps/web, apps/etl): all 56 test files (545 tests) passing.
- Production build & Wrangler dry-run: passed without regressions.