### PR TITLE
feat(web): add the local-authority decision panel on real E11.3-E11.5 data (E11.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The project follows a clean separation between three data classes: **base geospa
 - 🌧️ **Rainfall & weather radar** — TMD radar composites and rainfall telemetry with a scrubbable timeline.
 - 🏔️ **Dam & reservoir monitoring** — storage levels and capacity for reservoirs reporting in the selected province.
 - 🌏 **Earthquake feed** — near real-time seismic events cross-checked across USGS, EMSC and TMD.
+- 🏛️ **Local-authority (อปท.) decision support** — per-authority flood impact from real polygon intersection against the current GISTDA scene (flooded area/fraction and facilities-in-flood are measured; population/buildings exposed are an illustrative area-weighted share of the baseline), a flooded-fraction-ranked affected-authority list, and an alert banner that renders healthy, never-evaluated, degraded-fetch and unreachable states distinctly — covers the 431 local authorities with a real OSM boundary.
 - 📡 **Live source-health footer** — every panel discloses upstream freshness ("updated N minutes ago") and falls back to "unknown" instead of failing silently when a source is down.
 - 🔗 **Shareable permalinks** — camera position, province and layer state are encoded into the URL.
 - 📱 **Responsive layout** — a full desktop control-room view and a condensed mobile sheet for field use.
@@ -223,7 +224,7 @@ This is an attribution list, **not** a claim of authorship or endorsement — th
 
 ## Project status
 
-SIAHRA is deployed on `siahra-radar.co` as two independently released Cloudflare Workers — `siahra-web` (the static SPA and tile proxy) and `siahra-api` (bound to `/api/*`). The hazard layers listed in [Features](#features) above are live: 3D terrain for all 77 provinces, GISTDA flood extent, ThaiWater levels and dams, TMD radar, the earthquake feed and the source-health footer. The Durable-Object-backed API endpoints require a Workers Paid plan — see [`docs/deploy.md`](docs/deploy.md) for the deployment prerequisites.
+SIAHRA is deployed on `siahra-radar.co` as two independently released Cloudflare Workers — `siahra-web` (the static SPA and tile proxy) and `siahra-api` (bound to `/api/*`). The hazard layers listed in [Features](#features) above are live: 3D terrain for all 77 provinces, GISTDA flood extent, ThaiWater levels and dams, TMD radar, the earthquake feed, the local-authority decision-support panel (impact card, affected-authority list, alert banner) and the source-health footer. The Durable-Object-backed API endpoints require a Workers Paid plan — see [`docs/deploy.md`](docs/deploy.md) for the deployment prerequisites.
 
 What comes next — the ordered task list, milestones and the work deliberately deferred — is in [`docs/roadmap.md`](docs/roadmap.md). [`docs/SIAHRA-implement-plan.md`](docs/SIAHRA-implement-plan.md) remains the original research blueprint and data-source inventory; it is not a schedule.
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { BottomBar } from "./components/layout/BottomBar";
 import type { MapApi, MapInfo, MapLayers } from "./components/layout/Map3DCanvas";
 import { MapViewport } from "./components/layout/MapViewport";
@@ -15,6 +15,9 @@ import { useEarthquakeFeed } from "./hooks/useEarthquakeFeed";
 import { useDams } from "./hooks/useDams";
 import { useFloodExposure } from "./hooks/useFloodExposure";
 import { useFloodExtent } from "./hooks/useFloodExtent";
+import { useAffectedAuthorities } from "./hooks/useAffectedAuthorities";
+import { useActiveAlerts } from "./hooks/useActiveAlerts";
+import { useLocalAuthorityImpact } from "./hooks/useLocalAuthorityImpact";
 import { useRadar } from "./hooks/useRadar";
 import { TimelineBar } from "./components/layout/TimelineBar";
 import { useObservations } from "./hooks/useObservations";
@@ -28,6 +31,9 @@ import { WaterLevelCard } from "./components/hazard/WaterLevelCard";
 import { RainfallCard } from "./components/hazard/RainfallCard";
 import { DamCard } from "./components/hazard/DamCard";
 import { EarthquakeLiveCard } from "./components/hazard/EarthquakeLiveCard";
+import { ActiveAlertBanner } from "./components/hazard/ActiveAlertBanner";
+import { AffectedAuthorityList } from "./components/hazard/AffectedAuthorityList";
+import { ImpactSummaryCard } from "./components/hazard/ImpactSummaryCard";
 import { BRAND, DATA_ATTRIBUTION_TH } from "./branding";
 import type { CameraPose } from "./scene/setupScene";
 import type { QualityLevel, QualityMode } from "./scene/quality";
@@ -122,6 +128,13 @@ export default function App() {
   const floodExtent = useFloodExtent(provinceCode);
   // ชั้นปิดอยู่ = ไม่ยิงคำขอเลยแม้แต่ครั้งเดียว (รูปแบบเดียวกับ useRadar)
   const exposure = useFloodExposure(provinceCode, layers.exposure);
+  // E11.6 — แดชบอร์ดผลกระทบ อปท.: รายชื่อจัดอันดับ + แจ้งเตือนทั้งจังหวัด + ราย
+  // ละเอียดของ อปท. ที่เลือกอยู่ (สาม hook อิสระ ผูกกันด้วย provinceCode/id เดียวกัน
+  // ตามรูปแบบเดียวกับ observations/earthquakes/floodExtent/dams ด้านบน)
+  const affectedAuthorities = useAffectedAuthorities(provinceCode);
+  const activeAlerts = useActiveAlerts(provinceCode);
+  const [selectedAuthorityId, setSelectedAuthorityId] = useState<string | null>(null);
+  const localAuthorityImpact = useLocalAuthorityImpact(selectedAuthorityId);
   const thaiwater = sourceStatus(apiHealth.health, "thaiwater");
   // Stale/failed station data is drawn dimmed so nobody reads an old reading as current.
   // เงื่อนไข `!== "ok"` ครอบ `delayed` ด้วยโดยตั้งใจ (E3.3): ต้นทางตอบปกติแต่ค่า
@@ -216,7 +229,28 @@ export default function App() {
     initialPoseRef.current = null;
     setPose(null);
     setProvinceCode(code);
+    // เปลี่ยนจังหวัด = เลิกเลือก อปท. ทันที ห้ามให้ตัวเลขของ อปท. จังหวัดก่อนหน้า
+    // ค้างอยู่ใต้หัวข้อของจังหวัดใหม่แม้เสี้ยววินาที (บั๊กที่เวอร์ชันก่อนถูกย้อนกลับเจอ)
+    setSelectedAuthorityId(null);
   }, []);
+
+  // เมื่อรายชื่อ อปท. ที่ได้รับผลกระทบของจังหวัดนี้โหลดเสร็จและตัวที่เลือกอยู่ไม่ได้
+  // อยู่ในรายการนี้แล้ว (ยังไม่เคยเลือกเลย หรือเป็นตัวที่เลือกไว้จากจังหวัดก่อนหน้า
+  // ที่ setSelectedAuthorityId(null) ใน selectProvince ยังมาไม่ทัน) ให้เลือกอันดับ
+  // แรกให้อัตโนมัติ (อันดับแรก = โดนน้ำท่วมมากที่สุด) — เช็คด้วย "อยู่ในรายการไหม"
+  // ไม่ใช่แค่ "เป็น null ไหม" เพื่อไม่ให้ useLocalAuthorityImpact ค้าง poll id ของ
+  // จังหวัดเก่าต่อไปได้ในทุกกรณี ไม่ใช่แค่ตอนที่ผ่าน selectProvince เท่านั้น
+  const affectedAuthoritiesEntries = affectedAuthorities.entries;
+  useEffect(() => {
+    if (affectedAuthoritiesEntries.length === 0) return;
+    if (
+      selectedAuthorityId &&
+      affectedAuthoritiesEntries.some((e) => e.id === selectedAuthorityId)
+    ) {
+      return;
+    }
+    setSelectedAuthorityId(affectedAuthoritiesEntries[0].id);
+  }, [affectedAuthoritiesEntries, selectedAuthorityId]);
 
   // Search index: amphoe centroids (from station coordinates), stations, dams of this province.
   const places = useMemo<SearchPlace[]>(() => {
@@ -405,6 +439,43 @@ export default function App() {
               },
               { key: "flood", label: t("sheet.tab.flood"), content: <FloodExtentCard state={floodExtent} /> },
               {
+                // E11.6 — บนมือถือรวมทั้งสามคอมโพเนนต์ไว้แท็บเดียว (ไม่ใช่ "โหมดภาคสนาม"
+                // อะไรเป็นพิเศษ แค่เป็นการ์ดเดียวกับฝั่งเดสก์ท็อปวางต่อกัน) เพราะ
+                // MobileSheet เลื่อนได้อยู่แล้ว ไม่จำเป็นต้องตัดอะไรออก
+                key: "impact",
+                label: t("sheet.tab.impact"),
+                content: (
+                  <div className="flex flex-col gap-3">
+                    <ActiveAlertBanner
+                      state={activeAlerts}
+                      authorityNames={
+                        new Map(affectedAuthorities.entries.map((e) => [e.id, e.nameTh]))
+                      }
+                    />
+                    <AffectedAuthorityList
+                      state={affectedAuthorities}
+                      alerts={activeAlerts.data?.alerts ?? []}
+                      selectedId={selectedAuthorityId}
+                      onSelect={setSelectedAuthorityId}
+                    />
+                    <ImpactSummaryCard
+                      authority={
+                        affectedAuthorities.entries.find((e) => e.id === selectedAuthorityId) ?? null
+                      }
+                      state={localAuthorityImpact}
+                      health={apiHealth.health}
+                      alerts={
+                        selectedAuthorityId
+                          ? (activeAlerts.data?.alerts.filter(
+                              (a) => a.localAuthorityId === selectedAuthorityId,
+                            ) ?? [])
+                          : []
+                      }
+                    />
+                  </div>
+                ),
+              },
+              {
                 key: "water",
                 label: t("sheet.tab.water"),
                 content: (
@@ -458,6 +529,12 @@ export default function App() {
             earthquakes={earthquakes}
             floodExtent={floodExtent}
             dams={dams}
+            activeAlerts={activeAlerts}
+            affectedAuthorities={affectedAuthorities}
+            localAuthorityImpact={localAuthorityImpact}
+            selectedAuthorityId={selectedAuthorityId}
+            onSelectAuthority={setSelectedAuthorityId}
+            health={apiHealth.health}
             atIso={atIso}
             width={RIGHT_W}
             top={dockTop}

--- a/apps/web/src/components/hazard/ActiveAlertBanner.tsx
+++ b/apps/web/src/components/hazard/ActiveAlertBanner.tsx
@@ -1,0 +1,109 @@
+import { BellRing } from "lucide-react";
+import type { ActiveAlertsState } from "../../hooks/useActiveAlerts";
+import { ALERT_SEVERITY_STYLE } from "../../lib/alertSeverityStyle";
+import { formatAge, formatDateTime } from "../../lib/time";
+import { useLang } from "../../i18n/context";
+import { resolveError } from "../../lib/errorMessage";
+
+/**
+ * แถบแจ้งเตือน อปท. ของจังหวัดที่กำลังดู (E11.5 → E11.6)
+ *
+ * สี่สถานะที่ต้องแยกให้เห็นชัด ห้ามพับเป็นสถานะเดียวกัน (ดู `docs/roadmap.md`
+ * E11.6 และ `useActiveAlerts.ts`):
+ *   1. `evaluatedAt` เป็นเวลาจริง + `alerts` ว่าง = ประเมินแล้ว ไม่มีอะไร active
+ *   2. `evaluatedAt === null` = เอนจินยังไม่เคยประเมินเลย (สถานะจริงที่เกิดขึ้นได้
+ *      หลัง deploy ใหม่ หรือระหว่างรอ alarm ติ๊กแรก)
+ *   3. คำขอเองล้มเหลวและไม่มี `data` ค้างอยู่เลย (`error && !data`) = ติดต่อเอนจิน
+ *      ไม่ได้ — คนละเรื่องกับข้อ 2 ซึ่งเป็นคำตอบสำเร็จที่บอกว่า "ยังไม่มีอะไรต้อง
+ *      รายงาน"
+ *   4. คำขอ**รอบล่าสุด**ล้มเหลว แต่ยังมี `data.alerts` จากรอบก่อนค้างอยู่
+ *      (`error && data && alerts.length > 0`) = รายการที่เห็นอาจไม่ทันปัจจุบันแล้ว
+ *      — คนละเรื่องกับข้อ 1 (สด ต่อเชื่อมได้ปกติ) ต้องหรี่ลงพร้อมคำเตือน ไม่ใช่
+ *      เรนเดอร์เหมือนสถานะปกติ
+ *
+ * เวอร์ชันก่อนถูกย้อนกลับทำ `if (alerts.length === 0) return null` ซึ่งกลืนทั้ง
+ * สี่สถานะเป็น "ไม่แสดงอะไรเลย" — เป็นบั๊กที่ห้ามเกิดซ้ำ แถบนี้จึงเรนเดอร์เสมอ
+ */
+export function ActiveAlertBanner({
+  state,
+  authorityNames,
+}: {
+  state: ActiveAlertsState;
+  /** id → nameTh มาจาก `AffectedAuthoritiesState.entries` ของจังหวัดเดียวกัน —
+   *  ไม่มีใน map (ยังโหลดไม่เสร็จ หรือ อปท. นี้ไม่มีขอบเขต E11.2) ก็ยังแสดง id
+   *  ดิบได้ ไม่ปล่อยให้แถวหายไป */
+  authorityNames?: ReadonlyMap<string, string>;
+}) {
+  const { lang, t } = useLang();
+  const { data, loading, error } = state;
+
+  return (
+    <div className="glass flex flex-col gap-2 rounded-2xl px-3.5 py-2.5">
+      <div className="flex items-center gap-2 text-sm font-semibold text-[var(--color-fg)]">
+        <BellRing size={16} className="text-[var(--color-accent)]" aria-hidden="true" />
+        <span>{t("alert.banner.title")}</span>
+        {data && data.alerts.length > 0 ? (
+          <span className="ml-auto rounded bg-[var(--color-risk-high)]/15 px-1.5 text-[10px] text-[var(--color-risk-high)]">
+            {t("alert.banner.count", { n: data.alerts.length })}
+          </span>
+        ) : null}
+      </div>
+
+      {loading && !data ? (
+        <div className="h-6 animate-pulse rounded bg-white/8" />
+      ) : error && !data ? (
+        // สถานะ 3: คำขอเองล้มเหลว — ต่างจาก "ประเมินแล้วว่าไม่มีอะไร" (สถานะ 1)
+        <p className="text-xs text-[var(--color-danger)]">
+          {t("alert.banner.unreachable")}
+          {resolveError(t, error) ? ` (${resolveError(t, error)})` : ""}
+        </p>
+      ) : !data || data.evaluatedAt === null ? (
+        // สถานะ 2: ตอบสำเร็จแล้ว แต่ evaluatedAt เป็น null จริง ๆ — ยังไม่เคยประเมิน
+        <p className="text-xs text-[var(--color-fg-muted)]">{t("alert.banner.neverEvaluated")}</p>
+      ) : data.alerts.length === 0 ? (
+        // สถานะ 1: ประเมินแล้ว ไม่มีอะไร active
+        <p className="text-xs text-[var(--color-fg-muted)]">
+          {t("alert.banner.none")} · {t("alert.banner.evaluatedAge", { age: formatAge(lang, data.evaluatedAt) })}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {error ? (
+            // สถานะ 4: รายการนี้มาจากรอบก่อนที่สำเร็จ แต่รอบล่าสุดดึงพลาด — หรี่ลง
+            // พร้อมบอกว่าอาจไม่ทันปัจจุบัน แทนที่จะเรนเดอร์เหมือนข้อมูลสดปกติ
+            <p className="text-[10px] text-[var(--color-risk-medium)]">
+              {t("alert.banner.degraded")}
+              {resolveError(t, error) ? ` (${resolveError(t, error)})` : ""}
+            </p>
+          ) : null}
+          <ul className={`flex flex-col gap-1.5 ${error ? "opacity-70" : ""}`}>
+            {data.alerts.map((a) => {
+              const s = ALERT_SEVERITY_STYLE[a.level];
+              return (
+                <li
+                  key={a.id}
+                  className={`flex flex-col gap-0.5 rounded-lg px-2.5 py-1.5 text-xs ring-1 ring-inset ${s.ringClassName} ${
+                    a.stale ? "opacity-60" : ""
+                  }`}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${s.dotClassName}`} aria-hidden="true" />
+                    <span className={`font-semibold ${s.textClassName}`}>{t(s.labelKey)}</span>
+                    <span className="text-[var(--color-fg-subtle)]">
+                      {authorityNames?.get(a.localAuthorityId) ?? a.localAuthorityId}
+                    </span>
+                    {a.stale ? (
+                      <span className="ml-auto text-[10px] text-[var(--color-fg-subtle)]">{t("alert.banner.stale")}</span>
+                    ) : null}
+                  </span>
+                  <span className="text-[10px] text-[var(--color-fg-subtle)]">
+                    {t("alert.banner.triggeredAt", { time: formatDateTime(lang, a.triggeredAt) })}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/hazard/AffectedAuthorityList.tsx
+++ b/apps/web/src/components/hazard/AffectedAuthorityList.tsx
@@ -1,0 +1,109 @@
+import { ListTree } from "lucide-react";
+import type { AlertEvent } from "@siahra/shared-types";
+import type { AffectedAuthoritiesState } from "../../hooks/useAffectedAuthorities";
+import type { RankedAffectedAuthority } from "../../lib/affectedAuthorityRanking";
+import { Panel } from "../ui/Panel";
+import { formatNumber } from "../../lib/number";
+import { useLang } from "../../i18n/context";
+import { resolveError } from "../../lib/errorMessage";
+import { ALERT_SEVERITY_STYLE } from "../../lib/alertSeverityStyle";
+import { LOCAL_AUTHORITY_TYPE_KEY } from "../../lib/localAuthorityTypeLabel";
+
+function facilitiesCount(entry: RankedAffectedAuthority): number {
+  if (!entry.impact) return 0;
+  const f = entry.impact.facilitiesExposed;
+  return f.hospitals.length + f.schools.length + f.fireStations.length;
+}
+
+/**
+ * รายชื่อ อปท. ที่ได้รับผลกระทบในจังหวัดที่กำลังดู เรียงตามสัดส่วนพื้นที่ท่วม
+ * มากไปน้อย (E11.6) — เป็นทั้งรายการแสดงผลและกลไกเลือก อปท. ให้
+ * `ImpactSummaryCard` (ยังไม่มีการคลิกเลือกบนโพลิกอน 3 มิติ — ดู
+ * `scene/LocalAuthorityOutline.ts`, นอกขอบเขตงานนี้)
+ */
+export function AffectedAuthorityList({
+  state,
+  alerts,
+  selectedId,
+  onSelect,
+}: {
+  state: AffectedAuthoritiesState;
+  /** แจ้งเตือนที่ active ของทั้งจังหวัด (จาก `useActiveAlerts`) — ใช้ badge ระดับ
+   *  ความรุนแรงต่อแถว ใช้ป้ายสี/ข้อความชุดเดียวกับ `ActiveAlertBanner` */
+  alerts: readonly AlertEvent[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const { lang, t } = useLang();
+  const { entries, loading, error, coverage } = state;
+  const alertByAuthority = new Map(alerts.map((a) => [a.localAuthorityId, a]));
+
+  return (
+    <Panel
+      title={t("authorityList.title")}
+      icon={<ListTree size={16} className="text-[var(--color-accent)]" aria-hidden="true" />}
+    >
+      {loading && entries.length === 0 ? (
+        <div className="flex flex-col gap-1.5">
+          <div className="h-8 animate-pulse rounded bg-white/8" />
+          <div className="h-8 animate-pulse rounded bg-white/8" />
+        </div>
+      ) : error && entries.length === 0 ? (
+        <p className="rounded-lg bg-[var(--color-danger)]/10 px-2.5 py-2 text-xs text-[var(--color-danger)]">
+          {t("authorityList.loadError", { error: resolveError(t, error) ?? "" })}
+        </p>
+      ) : coverage === "none" || entries.length === 0 ? (
+        <p className="rounded-lg bg-[var(--color-bg-elevated)] px-2.5 py-3 text-center text-xs text-[var(--color-fg-muted)]">
+          {t("authorityList.empty.noCoverage")}
+        </p>
+      ) : (
+        <ul className="flex max-h-64 flex-col overflow-y-auto pr-0.5">
+          {entries.map((entry) => {
+            const alert = alertByAuthority.get(entry.id);
+            const active = entry.id === selectedId;
+            return (
+              <li key={entry.id} className="border-t border-white/8 first:border-t-0">
+                <button
+                  type="button"
+                  onClick={() => onSelect(entry.id)}
+                  aria-pressed={active}
+                  className={`flex w-full items-center gap-2 py-1.5 text-left transition-colors ${
+                    active ? "bg-[var(--color-accent)]/12" : "hover:bg-white/4"
+                  }`}
+                >
+                  <span className="w-14 shrink-0 text-right text-sm font-semibold tabular-nums text-[#4d94b8]">
+                    {entry.bucket === "measured" && entry.impact
+                      ? t("authorityList.floodedFraction", {
+                          pct: formatNumber(lang, (entry.impact.floodedFraction as number) * 100, 1),
+                        })
+                      : "—"}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs text-[var(--color-fg)]">{entry.nameTh}</p>
+                    <p className="truncate text-[10px] text-[var(--color-fg-subtle)]">
+                      {t(LOCAL_AUTHORITY_TYPE_KEY[entry.type])}
+                      {entry.bucket === "measured" && facilitiesCount(entry) > 0
+                        ? ` · ${t("authorityList.facilitiesCount", { n: facilitiesCount(entry) })}`
+                        : ""}
+                      {entry.bucket === "never-fetched" ? ` · ${t("authorityList.neverFetched")}` : ""}
+                      {entry.bucket === "unavailable" ? ` · ${t("authorityList.unavailable")}` : ""}
+                    </p>
+                  </div>
+                  {alert ? (
+                    <span
+                      className={`h-2 w-2 shrink-0 rounded-full ${ALERT_SEVERITY_STYLE[alert.level].dotClassName} ${
+                        alert.stale ? "opacity-50" : ""
+                      }`}
+                      title={t(ALERT_SEVERITY_STYLE[alert.level].labelKey)}
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Panel>
+  );
+}

--- a/apps/web/src/components/hazard/ImpactSummaryCard.tsx
+++ b/apps/web/src/components/hazard/ImpactSummaryCard.tsx
@@ -1,0 +1,188 @@
+import { ClipboardList } from "lucide-react";
+import type { AlertEvent, HealthResponse } from "@siahra/shared-types";
+import type { RankedAffectedAuthority } from "../../lib/affectedAuthorityRanking";
+import type { LocalAuthorityImpactState } from "../../hooks/useLocalAuthorityImpact";
+import { worstHealth } from "../../hooks/useLayerDescriptors";
+import { Panel } from "../ui/Panel";
+import { FreshnessMeta } from "../ui/FreshnessMeta";
+import { formatNumber } from "../../lib/number";
+import { useLang } from "../../i18n/context";
+import { resolveError } from "../../lib/errorMessage";
+import { ALERT_SEVERITY_STYLE } from "../../lib/alertSeverityStyle";
+import { LOCAL_AUTHORITY_TYPE_KEY } from "../../lib/localAuthorityTypeLabel";
+
+/**
+ * รายละเอียดของ อปท. หนึ่งรายที่ผู้ใช้เลือกจาก `AffectedAuthorityList` — E11.6
+ *
+ * ทุกตัวเลขที่นี่มาจาก `/exposure` (E11.3, baseline คงที่) และ `/impact`
+ * (E11.4, ตัดกับฉากน้ำท่วมปัจจุบัน) ตรง ๆ ไม่มีการคำนวณเพิ่มฝั่งเว็บ — ป้าย
+ * ชนิดความรู้ต่อฟิลด์มาจาก `descriptor` จริงของฟิลด์นั้น (`FreshnessMeta`) ไม่ใช่
+ * ป้ายเดียวทั้งการ์ด: `floodedAreaKm2`/`facilitiesExposed` เป็น `observed`
+ * (วัดจริงจากรูปหลายเหลี่ยม) ส่วน `populationExposed`/`buildingsExposed` เป็น
+ * `illustrative` (สัดส่วนพื้นที่ ไม่ใช่การนับจริง) — สองอย่างนี้ต้องแยกหน้าตากันได้
+ */
+export function ImpactSummaryCard({
+  authority,
+  state,
+  health,
+  alerts,
+}: {
+  authority: RankedAffectedAuthority | null;
+  state: LocalAuthorityImpactState;
+  health: HealthResponse | null;
+  alerts: readonly AlertEvent[];
+}) {
+  const { lang, t } = useLang();
+  const { exposure, impact } = state;
+
+  return (
+    <Panel
+      title={t("impact.card.title")}
+      icon={<ClipboardList size={16} className="text-[var(--color-accent)]" aria-hidden="true" />}
+    >
+      {!authority ? (
+        <p className="rounded-lg bg-[var(--color-bg-elevated)] px-2.5 py-3 text-center text-xs text-[var(--color-fg-muted)]">
+          {t("impact.card.selectPrompt")}
+        </p>
+      ) : exposure.notFound || impact.notFound ? (
+        <p className="rounded-lg bg-[var(--color-risk-medium)]/10 px-2.5 py-3 text-center text-xs text-[var(--color-risk-medium)]">
+          {t("impact.card.noCoverage")}
+        </p>
+      ) : (exposure.loading && !exposure.data) || (impact.loading && !impact.data) ? (
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-2/3 animate-pulse rounded bg-white/8" />
+          <div className="h-10 animate-pulse rounded bg-white/8" />
+          <div className="h-10 animate-pulse rounded bg-white/8" />
+        </div>
+      ) : exposure.error && !exposure.data && impact.error && !impact.data ? (
+        <p className="rounded-lg bg-[var(--color-danger)]/10 px-2.5 py-2 text-xs text-[var(--color-danger)]">
+          {t("impact.card.loadError", { error: resolveError(t, exposure.error ?? impact.error) ?? "" })}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div>
+            <p className="text-sm font-semibold text-[var(--color-fg)]">{authority.nameTh}</p>
+            <p className="text-[11px] text-[var(--color-fg-subtle)]">{t(LOCAL_AUTHORITY_TYPE_KEY[authority.type])}</p>
+          </div>
+
+          {alerts.length > 0 ? (
+            <ul className="flex flex-col gap-1">
+              {alerts.map((a) => {
+                const s = ALERT_SEVERITY_STYLE[a.level];
+                return (
+                  <li
+                    key={a.id}
+                    className={`flex items-center gap-1.5 rounded-lg px-2 py-1 text-[11px] ring-1 ring-inset ${s.ringClassName} ${a.stale ? "opacity-50" : ""}`}
+                  >
+                    <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${s.dotClassName}`} aria-hidden="true" />
+                    <span className={s.textClassName}>{t(s.labelKey)}</span>
+                    {a.stale ? <span className="text-[var(--color-fg-subtle)]">· {t("alert.banner.stale")}</span> : null}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+
+          {exposure.data ? (
+            <section className="flex flex-col gap-2">
+              <p className="text-[11px] font-semibold text-[var(--color-fg-muted)]">{t("impact.section.baseline")}</p>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.population.label")}</p>
+                  <p className="text-lg font-bold tabular-nums text-[var(--color-fg)]">
+                    {formatNumber(lang, exposure.data.exposure.population.estimate)}
+                  </p>
+                  <p className="text-[10px] text-[var(--color-fg-subtle)]">{t("impact.population.estimateNote")}</p>
+                  <FreshnessMeta
+                    descriptor={exposure.data.exposure.population.descriptor}
+                    health={worstHealth(exposure.data.exposure.population.descriptor.sourceIds, health)}
+                  />
+                </div>
+                <div>
+                  <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.buildings.label")}</p>
+                  <p className="text-lg font-bold tabular-nums text-[var(--color-fg)]">
+                    {formatNumber(lang, exposure.data.exposure.buildings.count)}
+                  </p>
+                  <FreshnessMeta
+                    descriptor={exposure.data.exposure.buildings.descriptor}
+                    health={worstHealth(exposure.data.exposure.buildings.descriptor.sourceIds, health)}
+                  />
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          {impact.data ? (
+            <section className="flex flex-col gap-2 border-t border-white/8 pt-2.5">
+              <p className="text-[11px] font-semibold text-[var(--color-fg-muted)]">{t("impact.section.flood")}</p>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.floodedArea.label")}</p>
+                  <p className="text-lg font-bold tabular-nums text-[#4d94b8]">
+                    {formatNumber(lang, impact.data.impact.floodedAreaKm2, 2)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.floodedFraction.label")}</p>
+                  <p className="text-lg font-bold tabular-nums text-[#4d94b8]">
+                    {impact.data.impact.floodedFraction === null
+                      ? "—"
+                      : `${formatNumber(lang, impact.data.impact.floodedFraction * 100, 1)}%`}
+                  </p>
+                  {impact.data.impact.floodedFraction === null ? (
+                    <p className="text-[10px] text-[var(--color-risk-medium)]">{t("impact.floodedFraction.neverFetched")}</p>
+                  ) : null}
+                </div>
+              </div>
+              <FreshnessMeta
+                descriptor={impact.data.impact.descriptor}
+                health={worstHealth(impact.data.impact.descriptor.sourceIds, health)}
+              />
+
+              <div>
+                <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.facilitiesExposed.label")}</p>
+                {(() => {
+                  const f = impact.data.impact.facilitiesExposed;
+                  const parts: string[] = [];
+                  if (f.hospitals.length) parts.push(t("impact.facilitiesExposed.hospitals", { n: f.hospitals.length }));
+                  if (f.schools.length) parts.push(t("impact.facilitiesExposed.schools", { n: f.schools.length }));
+                  if (f.fireStations.length)
+                    parts.push(t("impact.facilitiesExposed.fireStations", { n: f.fireStations.length }));
+                  return (
+                    <p className="text-sm text-[var(--color-fg)]">
+                      {parts.length > 0 ? parts.join(" · ") : t("impact.facilitiesExposed.none")}
+                    </p>
+                  );
+                })()}
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.populationExposed.label")}</p>
+                  <p className="text-lg font-bold tabular-nums text-[#c4b0f5]">
+                    {formatNumber(lang, impact.data.impact.populationExposed.estimate)}
+                  </p>
+                  <FreshnessMeta
+                    descriptor={impact.data.impact.populationExposed.descriptor}
+                    health={worstHealth(impact.data.impact.populationExposed.descriptor.sourceIds, health)}
+                  />
+                </div>
+                <div>
+                  <p className="text-[11px] text-[var(--color-fg-muted)]">{t("impact.buildingsExposed.label")}</p>
+                  <p className="text-lg font-bold tabular-nums text-[#c4b0f5]">
+                    {formatNumber(lang, impact.data.impact.buildingsExposed.estimate)}
+                  </p>
+                  <FreshnessMeta
+                    descriptor={impact.data.impact.buildingsExposed.descriptor}
+                    health={worstHealth(impact.data.impact.buildingsExposed.descriptor.sourceIds, health)}
+                  />
+                </div>
+              </div>
+              <p className="text-[10px] text-[var(--color-fg-subtle)]">{t("impact.method.areaWeighted")}</p>
+            </section>
+          ) : null}
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/apps/web/src/components/layout/RightPanel.tsx
+++ b/apps/web/src/components/layout/RightPanel.tsx
@@ -1,12 +1,19 @@
+import type { HealthResponse } from "@siahra/shared-types";
 import type { EarthquakeFeedState } from "../../hooks/useEarthquakeFeed";
 import type { DamsState } from "../../hooks/useDams";
 import type { FloodExtentState } from "../../hooks/useFloodExtent";
 import type { ObservationsState } from "../../hooks/useObservations";
+import type { AffectedAuthoritiesState } from "../../hooks/useAffectedAuthorities";
+import type { ActiveAlertsState } from "../../hooks/useActiveAlerts";
+import type { LocalAuthorityImpactState } from "../../hooks/useLocalAuthorityImpact";
 import { EarthquakeLiveCard } from "../hazard/EarthquakeLiveCard";
 import { DamCard } from "../hazard/DamCard";
 import { FloodExtentCard } from "../hazard/FloodExtentCard";
 import { RainfallCard } from "../hazard/RainfallCard";
 import { WaterLevelCard } from "../hazard/WaterLevelCard";
+import { ActiveAlertBanner } from "../hazard/ActiveAlertBanner";
+import { AffectedAuthorityList } from "../hazard/AffectedAuthorityList";
+import { ImpactSummaryCard } from "../hazard/ImpactSummaryCard";
 import { useT } from "../../i18n/context";
 import { resolveError } from "../../lib/errorMessage";
 
@@ -16,6 +23,12 @@ export function RightPanel({
   earthquakes,
   floodExtent,
   dams,
+  activeAlerts,
+  affectedAuthorities,
+  localAuthorityImpact,
+  selectedAuthorityId,
+  onSelectAuthority,
+  health,
   atIso,
   width,
   top,
@@ -24,12 +37,27 @@ export function RightPanel({
   earthquakes: EarthquakeFeedState;
   floodExtent: FloodExtentState;
   dams: DamsState;
+  /** E11.5/E11.6 — แจ้งเตือน อปท. ทั้งจังหวัดที่กำลังดู */
+  activeAlerts: ActiveAlertsState;
+  /** E11.6 — รายชื่อ อปท. ที่ได้รับผลกระทบ เรียงลำดับแล้ว */
+  affectedAuthorities: AffectedAuthoritiesState;
+  /** E11.6 — รายละเอียดของ อปท. ที่เลือกอยู่ */
+  localAuthorityImpact: LocalAuthorityImpactState;
+  selectedAuthorityId: string | null;
+  onSelectAuthority: (id: string) => void;
+  health: HealthResponse | null;
   atIso: string | null;
   width: number;
   top: number;
 }) {
   const t = useT();
   const { data, loading, error } = observations;
+  const selectedAuthority =
+    affectedAuthorities.entries.find((e) => e.id === selectedAuthorityId) ?? null;
+  const authorityNames = new Map(affectedAuthorities.entries.map((e) => [e.id, e.nameTh]));
+  const selectedAuthorityAlerts = selectedAuthorityId
+    ? (activeAlerts.data?.alerts.filter((a) => a.localAuthorityId === selectedAuthorityId) ?? [])
+    : [];
 
   return (
     <aside
@@ -50,7 +78,23 @@ export function RightPanel({
         </div>
       ) : null}
 
+      <ActiveAlertBanner state={activeAlerts} authorityNames={authorityNames} />
+
       <FloodExtentCard state={floodExtent} />
+
+      <AffectedAuthorityList
+        state={affectedAuthorities}
+        alerts={activeAlerts.data?.alerts ?? []}
+        selectedId={selectedAuthorityId}
+        onSelect={onSelectAuthority}
+      />
+
+      <ImpactSummaryCard
+        authority={selectedAuthority}
+        state={localAuthorityImpact}
+        health={health}
+        alerts={selectedAuthorityAlerts}
+      />
 
       <WaterLevelCard
         stations={data?.waterlevel ?? []}

--- a/apps/web/src/components/ui/FreshnessMeta.tsx
+++ b/apps/web/src/components/ui/FreshnessMeta.tsx
@@ -1,0 +1,64 @@
+import { ExternalLink } from "lucide-react";
+import type { HazardLayerDescriptor, SourceHealth } from "@siahra/shared-types";
+import { describeLayerFreshness } from "../../lib/layerFreshness";
+import { useLang } from "../../i18n/context";
+import type { Lang } from "../../i18n";
+import { useNow } from "../../hooks/useNow";
+
+/**
+ * ลิงก์ไปหน้า `/methodology/...` พร้อม `?lang=` ปัจจุบัน — คัดลอกมาจาก
+ * `MapLegend.tsx`'s ตัวเดียวกัน (ไม่ได้ export) หน้านั้นเป็นคนละ route ที่ไม่ได้
+ * mount `usePermalinkSync` จึงอ่านภาษาได้จาก query string เท่านั้น
+ */
+function methodologyHref(url: string, lang: Lang): string {
+  if (lang === "th" || url.includes("lang=")) return url;
+  return `${url}${url.includes("?") ? "&" : "?"}lang=${lang}`;
+}
+
+/**
+ * ป้ายชนิดความรู้ + บรรทัดเวลาของ `HazardLayerDescriptor` หนึ่งตัว — เวอร์ชันใช้
+ * นอก `MapLegend` (การ์ดข้อมูล อปท. มีหลาย descriptor ต่อการ์ดหนึ่งใบ ต่างจาก
+ * legend ที่มีหนึ่งต่อชั้น) เป็นตัวเดียวกับ `MapLegend.tsx`'s `LayerMeta` ทุก
+ * ประการ (ยืม `describeLayerFreshness` ตัวเดียวกัน) แต่ตัวนั้นไม่ได้ export —
+ * ไม่คุ้มที่จะแก้ MapLegend.tsx เพื่อ export ฟังก์ชัน 20 บรรทัดออกมาใช้ที่เดียว
+ * ในงานนี้ จึงประกอบใหม่จาก building block เดียวกัน
+ */
+export function FreshnessMeta({
+  descriptor,
+  health,
+}: {
+  descriptor: HazardLayerDescriptor;
+  health: SourceHealth | null;
+}) {
+  const { lang, t } = useLang();
+  const nowMs = useNow();
+  const f = describeLayerFreshness(descriptor, health, nowMs, lang, t);
+  return (
+    <span className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+      <span
+        className={`rounded px-1 py-px text-[9px] leading-[1.35] ring-1 ring-inset ${f.badge.className}`}
+        title={f.badge.title}
+      >
+        {f.badge.label}
+      </span>
+      <span
+        className={`text-[10px] ${f.amber ? "text-[var(--color-risk-medium)]" : "text-[var(--color-fg-subtle)]"}`}
+      >
+        {f.timeText}
+        {f.statusText ? ` · ${f.statusText}` : ""}
+      </span>
+      {descriptor.methodologyUrl ? (
+        <a
+          href={methodologyHref(descriptor.methodologyUrl, lang)}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="inline-flex items-center gap-0.5 text-[10px] text-[var(--color-accent)] hover:underline"
+        >
+          {t("freshness.methodology")}
+          <ExternalLink size={9} aria-hidden="true" />
+        </a>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/web/src/hooks/useActiveAlerts.ts
+++ b/apps/web/src/hooks/useActiveAlerts.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import type { ActiveAlertsResponse } from "@siahra/shared-types";
+import { errorMessage, type ErrorMessage } from "../lib/errorMessage";
+import { nextReconnectDelayMs } from "../lib/feed/backoff";
+
+export interface ActiveAlertsState {
+  data: ActiveAlertsResponse | null;
+  loading: boolean;
+  /**
+   * ตั้งเมื่อคำขอเองล้มเหลว (เครือข่ายขาด หรือ backend ตอบ non-2xx เช่น 503 ตอน
+   * `AlertEngineDO` ล้ม) — ต่างจาก `data.evaluatedAt === null` ซึ่งเป็นคำตอบ
+   * **สำเร็จ** ที่บอกว่าเอนจินยังไม่เคยประเมินเลย สองเรื่องนี้ต้องแสดงข้อความ
+   * คนละแบบ: "ติดต่อระบบแจ้งเตือนไม่ได้" (error) กับ "ยังไม่เคยประเมิน"
+   * (data.evaluatedAt === null) — ห้ามพับเป็นสถานะเดียวกัน
+   */
+  error: ErrorMessage | null;
+}
+
+// เอนจินประเมินทุก 5 นาที (alarm ของ AlertEngineDO) — poll ถี่กว่านั้นเล็กน้อยก็พอ
+const REFRESH_MS = 5 * 60 * 1000;
+
+/**
+ * แจ้งเตือนที่กำลัง active ของจังหวัดหนึ่ง (E11.5) — ใช้ทั้ง `ActiveAlertBanner`
+ * (ทั้งจังหวัด) และแหล่งข้อมูลตั้งต้นให้ `ImpactSummaryCard`/`AffectedAuthorityList`
+ * กรองเอาเฉพาะ อปท. ที่ตัวเองสนใจต่อ (client-side filter บน `alerts[]` เดียวกัน
+ * แทนที่จะยิง `?localAuthorityId=` ซ้ำอีกรอบ — ข้อมูลชุดเดียวกันอยู่แล้ว)
+ */
+export function useActiveAlerts(provinceCode: string | null): ActiveAlertsState {
+  const [state, setState] = useState<ActiveAlertsState>({ data: null, loading: true, error: null });
+
+  useEffect(() => {
+    setState({ data: null, loading: provinceCode !== null, error: null });
+    if (!provinceCode) return;
+
+    let cancelled = false;
+    let timer: number | null = null;
+    let attempt = 0;
+    const controller = new AbortController();
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/v1/alerts/active?province=${provinceCode}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as ActiveAlertsResponse;
+        if (cancelled) return;
+        attempt = 0;
+        setState({ data, loading: false, error: null });
+        timer = window.setTimeout(load, REFRESH_MS);
+      } catch (err) {
+        if (cancelled || controller.signal.aborted) return;
+        // คง data เดิมไว้ (ถ้ามี) — แถบแจ้งเตือนหรี่ลงพร้อมบอกว่าดึงพลาด แทนที่จะ
+        // สลับไปแสดง "ไม่มีอะไร active" ซึ่งไม่จริง
+        setState((s) => ({ ...s, loading: false, error: errorMessage(err, "error.loadFailed") }));
+        // ล้มเหลวติดกันหลายรอบ = ถอยห่างขึ้นเรื่อย ๆ (เพดาน 30 วิ) แทนที่จะยิงรัว
+        // ทุก ๆ ไม่กี่วินาทีตอนต้นทางกำลังมีปัญหาอยู่แล้ว — ใช้ backoff ตัวเดียวกับ
+        // useLocalAuthorityImpact.ts/useAffectedAuthorities.ts
+        const delay = nextReconnectDelayMs(attempt);
+        attempt += 1;
+        timer = window.setTimeout(load, delay);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [provinceCode]);
+
+  return state;
+}

--- a/apps/web/src/hooks/useAffectedAuthorities.ts
+++ b/apps/web/src/hooks/useAffectedAuthorities.ts
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import type { LocalAuthorityImpact, LocalAuthorityImpactResponse } from "@siahra/shared-types";
+import { aoiIdForProvince } from "../data/types";
+import { errorMessage, type ErrorMessage } from "../lib/errorMessage";
+import { nextReconnectDelayMs } from "../lib/feed/backoff";
+import { mapWithConcurrency } from "../lib/concurrency";
+import {
+  rankAffectedAuthorities,
+  type AffectedAuthorityCandidate,
+  type RankedAffectedAuthority,
+} from "../lib/affectedAuthorityRanking";
+import { loadAoiManifest, AoiNotBuiltError } from "../scene/loadAoiManifest";
+import { loadLocalAuthorityBoundaries } from "../scene/localAuthorityBoundaries";
+
+export interface AffectedAuthoritiesState {
+  /** จัดอันดับแล้ว — ดู `lib/affectedAuthorityRanking.ts` */
+  entries: RankedAffectedAuthority[];
+  loading: boolean;
+  /**
+   * ตั้งเมื่อขั้นตอนโหลดรายชื่อผู้สมัคร (manifest/geojson) ล้มเหลวจริง ๆ —
+   * **ไม่ได้ตั้ง** เมื่อจังหวัดนี้ไม่มีขอบเขต อปท. เลย (นั่นคือ `entries: []`
+   * แบบปกติ ไม่ใช่ error — ดู `coverage`)
+   */
+  error: ErrorMessage | null;
+  /**
+   * `"none"` = จังหวัดนี้ไม่มี อปท. รายใดมีขอบเขต E11.2 จริงเลย (พบได้ปกติ ส่วน
+   * ใหญ่ของประเทศยังไม่มีขอบเขต — ดู `apps/etl/data/sources/osm-admin/COVERAGE.md`)
+   * `"covered"` = มีอย่างน้อยหนึ่งราย `"unknown"` = ยังโหลดไม่เสร็จ/ไม่เคยลองเลย
+   */
+  coverage: "unknown" | "none" | "covered";
+}
+
+const EMPTY: AffectedAuthoritiesState = { entries: [], loading: false, error: null, coverage: "unknown" };
+
+// impact ขึ้นกับฉาก GISTDA ปัจจุบัน — คาบเดียวกับ useFloodExtent.ts/useLocalAuthorityImpact.ts
+const REFRESH_MS = 10 * 60 * 1000;
+// จำนวนคำขอ /impact พร้อมกันสูงสุดต่อจังหวัด — จังหวัดที่มากที่สุด (14) มี ~144
+// รายการที่มีขอบเขตจริง ยิงพร้อมกันหมดเป็นการถล่มโควตา rate-limit ของหน้าเดียวกัน
+// โดยไม่จำเป็น (ดู `apps/api/src/rateLimit.ts`: 300/นาที + burst — 144 ยังอยู่ใน
+// งบ แต่ไม่ควรยิงพร้อมกันทั้งหมดในคำขอเดียว)
+const CONCURRENCY = 6;
+
+/**
+ * รายชื่อ อปท. ที่ได้รับผลกระทบในจังหวัดที่กำลังดู เรียงลำดับแล้ว (E11.6)
+ *
+ * ที่มาของ "ผู้สมัคร" (อปท. ที่ควรลอง `/impact`) คือไฟล์ GeoJSON เดียวกับที่
+ * `scene/LocalAuthorityOutline.ts` ใช้วาดขอบเขต 3 มิติ (`loadLocalAuthorityBoundaries`)
+ * — ไม่ใช่ทะเบียนทั้งหมดของจังหวัด (`GET /local-authorities?province=NN`) ซึ่งมี
+ * อปท. ที่ไม่มีขอบเขตจริงปนอยู่มาก (เช่น สงขลามี 141 รายการในทะเบียน แต่มีขอบเขต
+ * จริงแค่ 2) การไล่ยิง `/impact` ทั้งทะเบียนจะได้ 404 เกือบทั้งหมดโดยเดาได้ล่วงหน้า
+ * อยู่แล้วว่าจะพลาด ซึ่งไม่มีประโยชน์และสิ้นเปลืองโควตาคำขอ
+ */
+export function useAffectedAuthorities(provinceCode: string | null): AffectedAuthoritiesState {
+  const [state, setState] = useState<AffectedAuthoritiesState>(EMPTY);
+
+  useEffect(() => {
+    setState({ ...EMPTY, loading: provinceCode !== null });
+    if (!provinceCode) return;
+
+    let cancelled = false;
+    let timer: number | null = null;
+    let attempt = 0;
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        const manifest = await loadAoiManifest(aoiIdForProvince(provinceCode));
+        const candidates = await loadLocalAuthorityBoundaries(manifest);
+        if (cancelled || controller.signal.aborted) return;
+
+        if (!candidates || candidates.length === 0) {
+          setState({ entries: [], loading: false, error: null, coverage: "none" });
+          timer = window.setTimeout(load, REFRESH_MS);
+          return;
+        }
+
+        const built: AffectedAuthorityCandidate[] = await mapWithConcurrency(
+          candidates,
+          CONCURRENCY,
+          async (c): Promise<AffectedAuthorityCandidate> => {
+            try {
+              const res = await fetch(`/api/v1/local-authorities/${c.id}/impact`, {
+                signal: controller.signal,
+              });
+              if (!res.ok) return { id: c.id, nameTh: c.nameTh, type: c.type, impact: null, unavailable: true };
+              const body = (await res.json()) as LocalAuthorityImpactResponse;
+              const impact: LocalAuthorityImpact = body.impact;
+              return { id: c.id, nameTh: c.nameTh, type: c.type, impact, unavailable: false };
+            } catch {
+              return { id: c.id, nameTh: c.nameTh, type: c.type, impact: null, unavailable: true };
+            }
+          },
+        );
+        if (cancelled || controller.signal.aborted) return;
+
+        attempt = 0;
+        setState({ entries: rankAffectedAuthorities(built), loading: false, error: null, coverage: "covered" });
+        timer = window.setTimeout(load, REFRESH_MS);
+      } catch (err) {
+        if (cancelled || controller.signal.aborted) return;
+        if (err instanceof AoiNotBuiltError) {
+          // จังหวัดนี้ยังไม่มี artefact ของ terrain เลย — เกิดได้เฉพาะระหว่าง
+          // ทดสอบ/พัฒนา ไม่ใช่ในโปรดักชัน แต่ไม่ใช่ความล้มเหลวของชั้นนี้เอง
+          setState({ entries: [], loading: false, error: null, coverage: "none" });
+          return;
+        }
+        setState((s) => ({ ...s, loading: false, error: errorMessage(err, "error.loadFailed") }));
+        const delay = nextReconnectDelayMs(attempt);
+        attempt += 1;
+        timer = window.setTimeout(load, delay);
+      }
+    };
+    void load();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [provinceCode]);
+
+  return state;
+}

--- a/apps/web/src/hooks/useLayerDescriptors.ts
+++ b/apps/web/src/hooks/useLayerDescriptors.ts
@@ -70,7 +70,17 @@ function withProvenance(
 /** เรียงจากดีสุดไปแย่สุด — ชั้นหนึ่งอาจใช้หลายแหล่ง จึงรายงานอันที่แย่ที่สุด */
 const HEALTH_ORDER: SourceHealth[] = ["ok", "delayed", "stale", "degraded", "down", "unknown"];
 
-function worstHealth(ids: readonly SourceId[], health: HealthResponse | null): SourceHealth | null {
+/** เรียงจากดีสุดไปแย่สุด — ชั้นหนึ่งอาจใช้หลายแหล่ง จึงรายงานอันที่แย่ที่สุด
+ *
+ * Exported for reuse outside this hook (e.g. `hooks/useLocalAuthorityImpact.ts`,
+ * `hooks/useAffectedAuthorities.ts`): any card that renders a `HazardLayerDescriptor`
+ * needs the same "worst of its `sourceIds`" join against `/api/v1/health`, and
+ * copying this loop a second time would let the two drift. `null` here means
+ * "no `sourceIds` matched a live entry in `/health`" — e.g. a purely
+ * static-reference source like `dla`/`osm`/`worldpop` that has no live feed and
+ * therefore no health row by design; callers must render that as "no live
+ * source to check", never as a green "ok" dot. */
+export function worstHealth(ids: readonly SourceId[], health: HealthResponse | null): SourceHealth | null {
   if (!health) return null;
   let worst: SourceHealth | null = null;
   for (const id of ids) {

--- a/apps/web/src/hooks/useLocalAuthorityImpact.ts
+++ b/apps/web/src/hooks/useLocalAuthorityImpact.ts
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import type { LocalAuthorityExposureResponse, LocalAuthorityImpactResponse } from "@siahra/shared-types";
+import { errorMessage, type ErrorMessage } from "../lib/errorMessage";
+import { nextReconnectDelayMs } from "../lib/feed/backoff";
+
+/**
+ * หนึ่งทรัพยากรของ อปท. ที่เลือกอยู่ (baseline exposure หรือ flood impact)
+ *
+ * `notFound` แยกออกจาก `error` โดยตั้งใจ: 404 ของสอง endpoint นี้แปลว่า "อปท.
+ * รายนี้ไม่มีขอบเขต E11.2 จริง หรือไม่มีเส้นฐาน E11.3 ให้คำนวณ" ซึ่งเป็นข้อเท็จจริง
+ * ถาวร (จนกว่าไปป์ไลน์จะรันใหม่) ไม่ใช่ความล้มเหลวชั่วคราวที่ควรลองใหม่ทุกไม่กี่
+ * วินาทีอย่าง network/5xx — ฝั่ง UI จึงต้องแสดงข้อความคนละแบบ และ hook นี้จงใจ
+ * **ไม่ตั้ง timer ลองใหม่** เมื่อเจอ 404 (ต่างจาก error ที่ backoff ต่อ)
+ */
+export interface LocalAuthorityResourceState<T> {
+  data: T | null;
+  loading: boolean;
+  error: ErrorMessage | null;
+  notFound: boolean;
+}
+
+const EMPTY = <T,>(): LocalAuthorityResourceState<T> => ({
+  data: null,
+  loading: false,
+  error: null,
+  notFound: false,
+});
+
+export interface LocalAuthorityImpactState {
+  exposure: LocalAuthorityResourceState<LocalAuthorityExposureResponse>;
+  impact: LocalAuthorityResourceState<LocalAuthorityImpactResponse>;
+}
+
+// exposure = E11.3 baseline (static-reference, สร้างครั้งเดียวต่อรอบ ETL) — รีเฟรช
+// ห่าง ๆ พอ ไม่ต้องตามติดเหมือนข้อมูลสด
+const EXPOSURE_REFRESH_MS = 30 * 60 * 1000;
+// impact = E11.4 flood intersection สด (ขึ้นกับฉาก GISTDA ปัจจุบัน) — คาบเดียวกับ
+// useFloodExtent.ts เพราะมันคือข้อมูลชุดเดียวกันที่ถูกตัดกับขอบเขต อปท.
+const IMPACT_REFRESH_MS = 10 * 60 * 1000;
+
+/**
+ * ดึงทั้ง baseline exposure (E11.3) และ flood impact (E11.4) ของ อปท. หนึ่งราย
+ * ที่ผู้ใช้เลือกจาก `AffectedAuthorityList` — สอง endpoint คนละคาบรีเฟรชกัน จึง
+ * เป็นสอง polling loop อิสระ ไม่ใช่ทรัพยากรเดียว แต่ผูกกับ `authorityId` เดียวกัน
+ * และรีเซ็ตพร้อมกันทุกครั้งที่เปลี่ยนตัวเลือก (ห้ามให้ตัวเลขของ อปท. เก่าค้างอยู่
+ * ใต้หัวข้อของ อปท. ใหม่แม้เสี้ยววินาที — นี่คือบั๊กที่เวอร์ชันก่อนถูกย้อนกลับเจอ)
+ */
+export function useLocalAuthorityImpact(authorityId: string | null): LocalAuthorityImpactState {
+  const exposure = useLocalAuthorityResource<LocalAuthorityExposureResponse>(
+    authorityId,
+    (id) => `/api/v1/local-authorities/${id}/exposure`,
+    EXPOSURE_REFRESH_MS,
+  );
+  const impact = useLocalAuthorityResource<LocalAuthorityImpactResponse>(
+    authorityId,
+    (id) => `/api/v1/local-authorities/${id}/impact`,
+    IMPACT_REFRESH_MS,
+  );
+  return { exposure, impact };
+}
+
+function useLocalAuthorityResource<T>(
+  authorityId: string | null,
+  urlFor: (id: string) => string,
+  refreshMs: number,
+): LocalAuthorityResourceState<T> {
+  const [state, setState] = useState<LocalAuthorityResourceState<T>>(EMPTY<T>());
+
+  useEffect(() => {
+    // สลับ อปท. (รวมถึงเคลียร์การเลือก) = ทิ้งผลของรายการก่อนหน้าทันที ไม่ใช่แค่
+    // ตอน fetch ใหม่กลับมา
+    setState(authorityId ? { data: null, loading: true, error: null, notFound: false } : EMPTY<T>());
+    if (!authorityId) return;
+
+    let cancelled = false;
+    let timer: number | null = null;
+    let attempt = 0;
+    const controller = new AbortController();
+    const url = urlFor(authorityId);
+
+    const load = async () => {
+      try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (res.status === 404) {
+          if (cancelled) return;
+          // ถาวร (จนกว่า ETL จะรันใหม่) — ไม่ตั้ง timer ลองใหม่
+          setState({ data: null, loading: false, error: null, notFound: true });
+          return;
+        }
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as T;
+        if (cancelled) return;
+        attempt = 0;
+        setState({ data, loading: false, error: null, notFound: false });
+        timer = window.setTimeout(load, refreshMs);
+      } catch (err) {
+        if (cancelled || controller.signal.aborted) return;
+        // คง data เดิม (ถ้ามี) ไว้ — การ์ดหรี่ลงพร้อมบอกอายุของค่าล่าสุด ซื่อสัตย์
+        // กว่าทำให้ตัวเลขหายไปเงียบ ๆ ระหว่างรอบที่ดึงพลาด
+        setState((s) => ({ ...s, loading: false, error: errorMessage(err, "error.loadFailed"), notFound: false }));
+        // ล้มเหลวติดกันหลายรอบ = ถอยห่างขึ้นเรื่อย ๆ (เพดาน 30 วิ) แทนที่จะยิงรัว
+        // ทุก ๆ ไม่กี่วินาทีตอนต้นทางกำลังมีปัญหาอยู่แล้ว — ใช้ backoff ตัวเดียวกับ
+        // ที่ WebSocket แผ่นดินไหวใช้ reconnect
+        const delay = nextReconnectDelayMs(attempt);
+        attempt += 1;
+        timer = window.setTimeout(load, delay);
+      }
+    };
+    void load();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer !== null) window.clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- urlFor สร้างใหม่ทุกเรนเดอร์แต่เป็นฟังก์ชันบริสุทธิ์ที่ผูกกับ authorityId อยู่แล้ว
+  }, [authorityId, refreshMs]);
+
+  return state;
+}

--- a/apps/web/src/i18n/en.ts
+++ b/apps/web/src/i18n/en.ts
@@ -293,6 +293,7 @@ export const en: Record<keyof typeof th, string> = {
   "sheet.tab.province": "Province",
   "sheet.tab.layers": "Layers",
   "sheet.tab.flood": "Flood",
+  "sheet.tab.impact": "Local-authority impact",
   "sheet.tab.water": "Water level",
   "sheet.tab.rain": "Rain",
   "sheet.tab.dams": "Dams",
@@ -464,4 +465,57 @@ export const en: Record<keyof typeof th, string> = {
    */
   "methodology.thaiOnly":
     "This methodology document is available in Thai only; there is no English translation yet.",
+
+  // ── Local-authority (อปท.) types (E11.1) ────────────────────────────────
+  "localAuthority.type.provincial_admin_org": "Provincial admin org (อบจ.)",
+  "localAuthority.type.city_municipality": "City municipality",
+  "localAuthority.type.town_municipality": "Town municipality",
+  "localAuthority.type.subdistrict_municipality": "Subdistrict municipality",
+  "localAuthority.type.subdistrict_admin_org": "Subdistrict admin org (อบต.)",
+  "localAuthority.type.special_admin_area": "Special local-authority area",
+
+  // ── Local-authority impact summary (E11.6) ──────────────────────────────
+  "impact.card.title": "Local-authority impact summary",
+  "impact.card.selectPrompt": "Select a local authority from the list below to see details",
+  "impact.card.noCoverage":
+    "This local authority has no real boundary or baseline data to compute impact against yet",
+  "impact.card.loadError": "Failed to load impact data: {error}",
+  "impact.section.baseline": "Baseline (static)",
+  "impact.section.flood": "Current flood impact",
+  "impact.population.label": "Population",
+  "impact.population.estimateNote": "WorldPop 2020 estimate — not a real headcount",
+  "impact.buildings.label": "Buildings (baseline)",
+  "impact.floodedArea.label": "Flooded area",
+  "impact.floodedFraction.label": "Share of area flooded",
+  "impact.floodedFraction.neverFetched": "GISTDA has never fetched a flood scene successfully",
+  "impact.facilitiesExposed.label": "Key facilities inside the flooded area",
+  "impact.facilitiesExposed.hospitals": "{n} hospitals",
+  "impact.facilitiesExposed.schools": "{n} schools",
+  "impact.facilitiesExposed.fireStations": "{n} fire stations",
+  "impact.facilitiesExposed.none": "No key facilities inside the flooded area right now",
+  "impact.populationExposed.label": "Population possibly exposed (area-weighted share)",
+  "impact.buildingsExposed.label": "Buildings possibly exposed (area-weighted share)",
+  "impact.method.areaWeighted":
+    "Computed from the flooded area's share of the baseline — not a per-building count, not a forecast",
+
+  // ── Local-authority alert banner (E11.6) ────────────────────────────────
+  "alert.banner.title": "Local-authority alerts",
+  "alert.banner.neverEvaluated": "The alert engine has never evaluated since it started",
+  "alert.banner.unreachable": "Cannot reach the alert engine right now",
+  "alert.banner.none": "Evaluated — nothing active right now",
+  "alert.banner.degraded": "Could not reach the alert engine on the latest refresh — the list below may be out of date",
+  "alert.banner.evaluatedAge": "Last evaluated {age}",
+  "alert.banner.stale": "Held — station missing from the latest batch",
+  "alert.banner.triggeredAt": "Since {time}",
+  "alert.banner.count": "{n} active",
+
+  // ── Affected local-authority list (E11.6) ───────────────────────────────
+  "authorityList.title": "Affected local authorities",
+  "authorityList.empty.noCoverage":
+    "No local authority in this province has real E11.2 boundary coverage to compute against",
+  "authorityList.loadError": "Failed to load the authority list: {error}",
+  "authorityList.floodedFraction": "{pct}% flooded",
+  "authorityList.neverFetched": "GISTDA has never been fetched successfully",
+  "authorityList.unavailable": "Could not check this one's impact",
+  "authorityList.facilitiesCount": "{n} key facilities in the flooded area",
 };

--- a/apps/web/src/i18n/th.ts
+++ b/apps/web/src/i18n/th.ts
@@ -321,6 +321,7 @@ export const th = {
   "sheet.tab.province": "จังหวัด",
   "sheet.tab.layers": "ชั้นข้อมูล",
   "sheet.tab.flood": "น้ำท่วม",
+  "sheet.tab.impact": "ผลกระทบ อปท.",
   "sheet.tab.water": "ระดับน้ำ",
   "sheet.tab.rain": "ฝน",
   "sheet.tab.dams": "เขื่อน",
@@ -489,4 +490,57 @@ export const th = {
    */
   "methodology.thaiOnly":
     "เอกสารวิธีคำนวณฉบับนี้มีเฉพาะภาษาไทย ยังไม่มีฉบับแปลเป็นภาษาอังกฤษ",
+
+  // ── ประเภท อปท. (E11.1) ───────────────────────────────────────────────
+  "localAuthority.type.provincial_admin_org": "อบจ.",
+  "localAuthority.type.city_municipality": "เทศบาลนคร",
+  "localAuthority.type.town_municipality": "เทศบาลเมือง",
+  "localAuthority.type.subdistrict_municipality": "เทศบาลตำบล",
+  "localAuthority.type.subdistrict_admin_org": "อบต.",
+  "localAuthority.type.special_admin_area": "ท้องถิ่นรูปแบบพิเศษ",
+
+  // ── สรุปผลกระทบ อปท. (E11.6) ─────────────────────────────────────────
+  "impact.card.title": "สรุปผลกระทบ อปท.",
+  "impact.card.selectPrompt": "เลือก อปท. จากรายการด้านล่างเพื่อดูรายละเอียด",
+  "impact.card.noCoverage":
+    "อปท. รายนี้ยังไม่มีขอบเขตหรือเส้นฐานข้อมูลจริงให้คำนวณผลกระทบ",
+  "impact.card.loadError": "โหลดข้อมูลผลกระทบไม่สำเร็จ: {error}",
+  "impact.section.baseline": "ข้อมูลพื้นฐาน (คงที่)",
+  "impact.section.flood": "ผลกระทบจากน้ำท่วมปัจจุบัน",
+  "impact.population.label": "ประชากร",
+  "impact.population.estimateNote": "ประมาณการ WorldPop 2020 — ไม่ใช่ตัวเลขนับจริง",
+  "impact.buildings.label": "อาคาร (เส้นฐาน)",
+  "impact.floodedArea.label": "พื้นที่น้ำท่วม",
+  "impact.floodedFraction.label": "สัดส่วนพื้นที่ท่วม",
+  "impact.floodedFraction.neverFetched": "GISTDA ยังไม่เคยดึงฉากน้ำท่วมสำเร็จเลย",
+  "impact.facilitiesExposed.label": "สถานที่สำคัญในพื้นที่น้ำท่วม",
+  "impact.facilitiesExposed.hospitals": "โรงพยาบาล {n}",
+  "impact.facilitiesExposed.schools": "โรงเรียน {n}",
+  "impact.facilitiesExposed.fireStations": "สถานีดับเพลิง {n}",
+  "impact.facilitiesExposed.none": "ไม่มีสถานที่สำคัญในพื้นที่น้ำท่วมขณะนี้",
+  "impact.populationExposed.label": "ประชากรที่อาจเผชิญน้ำท่วม (คำนวณจากสัดส่วนพื้นที่)",
+  "impact.buildingsExposed.label": "อาคารที่อาจเผชิญน้ำท่วม (คำนวณจากสัดส่วนพื้นที่)",
+  "impact.method.areaWeighted":
+    "คำนวณจากสัดส่วนพื้นที่ที่ถูกน้ำท่วมทับเส้นฐาน ไม่ใช่การนับทีละหลัง ไม่ใช่การพยากรณ์",
+
+  // ── แถบแจ้งเตือน อปท. (E11.6) ─────────────────────────────────────────
+  "alert.banner.title": "การแจ้งเตือน อปท.",
+  "alert.banner.neverEvaluated": "ระบบแจ้งเตือนยังไม่เคยประมวลผลเลยตั้งแต่เริ่มทำงาน",
+  "alert.banner.unreachable": "ติดต่อระบบแจ้งเตือนไม่ได้ในขณะนี้",
+  "alert.banner.none": "ประเมินแล้ว — ไม่มีการแจ้งเตือนที่ active อยู่ในขณะนี้",
+  "alert.banner.degraded": "เชื่อมต่อระบบแจ้งเตือนไม่ได้ในรอบล่าสุด — รายการด้านล่างอาจไม่ทันปัจจุบัน",
+  "alert.banner.evaluatedAge": "ประเมินล่าสุด {age}",
+  "alert.banner.stale": "ค้าง — สถานีขาดข้อมูลในรอบล่าสุด",
+  "alert.banner.triggeredAt": "เริ่มเมื่อ {time}",
+  "alert.banner.count": "{n} รายการ active",
+
+  // ── รายชื่อ อปท. ที่ได้รับผลกระทบ (E11.6) ───────────────────────────────
+  "authorityList.title": "อปท. ที่ได้รับผลกระทบ",
+  "authorityList.empty.noCoverage":
+    "จังหวัดนี้ยังไม่มี อปท. รายใดมีขอบเขต E11.2 จริงให้คำนวณ",
+  "authorityList.loadError": "โหลดรายชื่อ อปท. ไม่สำเร็จ: {error}",
+  "authorityList.floodedFraction": "ท่วม {pct}%",
+  "authorityList.neverFetched": "GISTDA ยังไม่เคยดึงข้อมูลสำเร็จ",
+  "authorityList.unavailable": "ตรวจสอบผลกระทบของรายนี้ไม่สำเร็จ",
+  "authorityList.facilitiesCount": "{n} สถานที่สำคัญในพื้นที่ท่วม",
 } as const;

--- a/apps/web/src/lib/affectedAuthorityRanking.test.ts
+++ b/apps/web/src/lib/affectedAuthorityRanking.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { LocalAuthorityImpact } from "@siahra/shared-types";
+import { rankAffectedAuthorities, type AffectedAuthorityCandidate } from "./affectedAuthorityRanking";
+
+function impact(overrides: Partial<LocalAuthorityImpact> = {}): LocalAuthorityImpact {
+  return {
+    localAuthorityId: "TH-LAO-0000000",
+    authorityAreaKm2: 10,
+    floodedAreaKm2: 0,
+    floodedFraction: 0,
+    facilitiesExposed: { hospitals: [], schools: [], fireStations: [] },
+    populationExposed: { estimate: 0, method: "area-weighted", descriptor: DESCRIPTOR },
+    buildingsExposed: { estimate: 0, method: "area-weighted", descriptor: DESCRIPTOR },
+    descriptor: DESCRIPTOR,
+    computedAt: "2026-08-23T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const DESCRIPTOR = {
+  id: "local-authority-flood-impact",
+  epistemicClass: "observed" as const,
+  liveOrStatic: "live" as const,
+  fetchedAt: "2026-08-23T00:00:00Z",
+  sourceIds: [],
+};
+
+function candidate(
+  id: string,
+  overrides: Partial<AffectedAuthorityCandidate> = {},
+): AffectedAuthorityCandidate {
+  return {
+    id,
+    nameTh: id,
+    type: "subdistrict_admin_org",
+    impact: impact(),
+    unavailable: false,
+    ...overrides,
+  };
+}
+
+describe("rankAffectedAuthorities", () => {
+  it("เรียง measured ตาม floodedFraction มากไปน้อย", () => {
+    const out = rankAffectedAuthorities([
+      candidate("a", { impact: impact({ floodedFraction: 0.1 }) }),
+      candidate("b", { impact: impact({ floodedFraction: 0.8 }) }),
+      candidate("c", { impact: impact({ floodedFraction: 0.4 }) }),
+    ]);
+    expect(out.map((e) => e.id)).toEqual(["b", "c", "a"]);
+    expect(out.every((e) => e.bucket === "measured")).toBe(true);
+  });
+
+  it("เสมอกันที่ floodedFraction แล้วเรียงตามจำนวนสถานที่สำคัญมากไปน้อย", () => {
+    const out = rankAffectedAuthorities([
+      candidate("few", {
+        impact: impact({ floodedFraction: 0.5, facilitiesExposed: { hospitals: [], schools: [], fireStations: [] } }),
+      }),
+      candidate("many", {
+        impact: impact({
+          floodedFraction: 0.5,
+          facilitiesExposed: {
+            hospitals: [{ osmId: "h1", nameTh: null, lat: 0, lon: 0 }],
+            schools: [{ osmId: "s1", nameTh: null, lat: 0, lon: 0 }],
+            fireStations: [],
+          },
+        }),
+      }),
+    ]);
+    expect(out.map((e) => e.id)).toEqual(["many", "few"]);
+  });
+
+  it("ไม่เอา floodedFraction: null (ไม่เคยดึงสำเร็จ) มาเรียงปนกับ 0 (ดึงสำเร็จแต่ไม่ท่วม)", () => {
+    const out = rankAffectedAuthorities([
+      candidate("never-fetched", { impact: impact({ floodedFraction: null, floodedAreaKm2: null }) }),
+      candidate("zero-flood", { impact: impact({ floodedFraction: 0 }) }),
+      candidate("flooded", { impact: impact({ floodedFraction: 0.2 }) }),
+    ]);
+    // measured (รวม 0 จริง) มาก่อนเสมอ ตามด้วย never-fetched
+    expect(out.map((e) => e.id)).toEqual(["flooded", "zero-flood", "never-fetched"]);
+    expect(out.find((e) => e.id === "never-fetched")?.bucket).toBe("never-fetched");
+    expect(out.find((e) => e.id === "zero-flood")?.bucket).toBe("measured");
+  });
+
+  it("อปท. ที่คำขอ /impact ของตัวเองล้มเหลว (unavailable) อยู่ท้ายสุดเสมอ", () => {
+    const out = rankAffectedAuthorities([
+      candidate("failed", { impact: null, unavailable: true }),
+      candidate("never-fetched", { impact: impact({ floodedFraction: null }) }),
+      candidate("flooded", { impact: impact({ floodedFraction: 0.9 }) }),
+    ]);
+    expect(out.map((e) => e.id)).toEqual(["flooded", "never-fetched", "failed"]);
+    expect(out.find((e) => e.id === "failed")?.bucket).toBe("unavailable");
+  });
+
+  it("ภายในกลุ่มเดียวกัน (never-fetched/unavailable) เรียงตามชื่อไทยเพื่อผลลัพธ์นิ่ง", () => {
+    const out = rankAffectedAuthorities([
+      candidate("z", { nameTh: "ฮ", impact: impact({ floodedFraction: null }) }),
+      candidate("a", { nameTh: "ก", impact: impact({ floodedFraction: null }) }),
+    ]);
+    expect(out.map((e) => e.id)).toEqual(["a", "z"]);
+  });
+});

--- a/apps/web/src/lib/affectedAuthorityRanking.ts
+++ b/apps/web/src/lib/affectedAuthorityRanking.ts
@@ -1,0 +1,78 @@
+/**
+ * การจัดอันดับ อปท. ที่ได้รับผลกระทบในจังหวัดหนึ่ง — โมดูลบริสุทธิ์ที่
+ * `hooks/useAffectedAuthorities.ts` ใช้ เพื่อให้เทสได้โดยไม่ต้องยุ่งกับ fetch/timer
+ *
+ * กติกาความซื่อสัตย์ต่อข้อมูลข้อเดียวที่ไฟล์นี้บังคับ: **ห้ามเอา `floodedFraction:
+ * null` (GISTDA ยังไม่เคยดึงสำเร็จ) มาเรียงปนกับ `0` (ดึงสำเร็จแล้วแต่ไม่ท่วมเลย)**
+ * — สอง อปท. นี้ต้องอยู่คนละกลุ่มบนหน้าจอเสมอ ไม่ใช่แค่คนละแถวเฉย ๆ
+ */
+import type { LocalAuthorityImpact, LocalAuthorityType } from "@siahra/shared-types";
+
+/** อปท. หนึ่งรายการที่มีขอบเขตจริง (E11.2) ในจังหวัดที่กำลังดู — ก่อนจัดอันดับ */
+export interface AffectedAuthorityCandidate {
+  id: string;
+  nameTh: string;
+  type: LocalAuthorityType;
+  /**
+   * ผลจาก `GET /:id/impact` — `null` เมื่อคำขอของ อปท. รายนี้เอง**ล้มเหลว**
+   * (เครือข่ายขาด/5xx) ต่างจาก `impact.floodedFraction === null` ที่แปลว่าคำขอ
+   * สำเร็จแต่ GISTDA เองยังไม่เคยดึงฉากใดสำเร็จเลย — สองเรื่องนี้คนละสาเหตุ แต่ผล
+   * บนหน้าจอเหมือนกัน (ไม่มีตัวเลขให้จัดอันดับ) จึงรวมเป็นบักเก็ตเดียวกันได้อย่าง
+   * ปลอดภัยผ่าน `unavailable`
+   */
+  impact: LocalAuthorityImpact | null;
+  /** true = คำขอ `/impact` ของ อปท. รายนี้เองล้มเหลว (ต่างจาก 404 ซึ่งไม่ควรอยู่ใน
+   *  รายการนี้ตั้งแต่แรก เพราะ candidate มาจากขอบเขต E11.2 จริงที่มีอยู่แล้ว) */
+  unavailable: boolean;
+}
+
+export type AffectedAuthorityBucket = "measured" | "never-fetched" | "unavailable";
+
+export interface RankedAffectedAuthority extends AffectedAuthorityCandidate {
+  bucket: AffectedAuthorityBucket;
+}
+
+function facilitiesCount(impact: LocalAuthorityImpact): number {
+  const f = impact.facilitiesExposed;
+  return f.hospitals.length + f.schools.length + f.fireStations.length;
+}
+
+function bucketOf(c: AffectedAuthorityCandidate): AffectedAuthorityBucket {
+  if (c.unavailable || !c.impact) return "unavailable";
+  if (c.impact.floodedFraction === null) return "never-fetched";
+  return "measured";
+}
+
+const BUCKET_ORDER: Record<AffectedAuthorityBucket, number> = {
+  measured: 0,
+  "never-fetched": 1,
+  unavailable: 2,
+};
+
+/**
+ * เรียง: `measured` (มีตัวเลขจริง) ก่อนเสมอ → เรียงตาม `floodedFraction` มากไปน้อย
+ * → เสมอกันเรียงตามจำนวนสถานที่สำคัญที่ถูกน้ำท่วม (`facilitiesExposed`) มากไปน้อย
+ * จากนั้น `never-fetched` (GISTDA ไม่เคยดึงสำเร็จ) แล้วค่อย `unavailable`
+ * (คำขอของรายนี้เองล้มเหลว) — ทั้งสองกลุ่มหลังเรียงตามชื่อไทยเพื่อให้ผลลัพธ์
+ * นิ่ง (deterministic) ไม่ใช่ตามลำดับที่คำขอ async กลับมาถึงก่อน-หลัง
+ */
+export function rankAffectedAuthorities(
+  candidates: readonly AffectedAuthorityCandidate[],
+): RankedAffectedAuthority[] {
+  return candidates
+    .map((c) => ({ ...c, bucket: bucketOf(c) }))
+    .sort((a, b) => {
+      const order = BUCKET_ORDER[a.bucket] - BUCKET_ORDER[b.bucket];
+      if (order !== 0) return order;
+      if (a.bucket === "measured") {
+        // bucket === "measured" รับประกันว่า impact และ floodedFraction ไม่เป็น null
+        const fa = a.impact as LocalAuthorityImpact;
+        const fb = b.impact as LocalAuthorityImpact;
+        const fractionDelta = (fb.floodedFraction as number) - (fa.floodedFraction as number);
+        if (fractionDelta !== 0) return fractionDelta;
+        const facilityDelta = facilitiesCount(fb) - facilitiesCount(fa);
+        if (facilityDelta !== 0) return facilityDelta;
+      }
+      return a.nameTh.localeCompare(b.nameTh, "th");
+    });
+}

--- a/apps/web/src/lib/alertSeverityStyle.ts
+++ b/apps/web/src/lib/alertSeverityStyle.ts
@@ -1,0 +1,38 @@
+/**
+ * ภาษาภาพของระดับแจ้งเตือน อปท. (E11.5/E11.6) — ใช้ร่วมกันทั้ง `ActiveAlertBanner`
+ * และ `AffectedAuthorityList` ไม่ให้มีสีคนละชุดสำหรับความหมายเดียวกัน
+ *
+ * `AlertSeverityTier` ("high" | "severe") เป็นเซตย่อยของ `ExposureLevel` เดียวกับ
+ * ที่ `apps/api/src/exposure/compute.ts` ใช้อยู่แล้ว — ป้ายข้อความจึงยืมคีย์เดิม
+ * จาก `legend.exposure.level.*` ตรง ๆ ไม่สร้างคำแปลคู่ขนานขึ้นมาใหม่
+ *
+ * **สีจงใจไม่ยืมจาก `lib/exposureStyle.ts`**: ไล่โทนม่วง→บานเย็นของไฟล์นั้นถูก
+ * เลือกไว้ให้ต่างจากสีของ "ค่าที่วัดได้จริง" (ส้ม/แดง) อย่างตั้งใจ — สถานีที่
+ * แจ้งเตือนอยู่นี้มาจากสถานีที่วัดได้จริง ไม่ใช่ชั้นภาพประกอบ การทาสีม่วงจึงกลับ
+ * ความหมายที่ไฟล์นั้นพยายามรักษาไว้ จึงใช้โทเคนความเสี่ยงเดียวกับ `WaterLevelCard`/
+ * `EarthquakeLiveCard` (`--color-risk-high`/`--color-risk-extreme`) แทน
+ */
+import type { AlertSeverityTier } from "@siahra/shared-types";
+import type { MessageKey } from "../i18n";
+
+export interface AlertSeverityStyle {
+  labelKey: MessageKey;
+  textClassName: string;
+  dotClassName: string;
+  ringClassName: string;
+}
+
+export const ALERT_SEVERITY_STYLE: Record<AlertSeverityTier, AlertSeverityStyle> = {
+  high: {
+    labelKey: "legend.exposure.level.high",
+    textClassName: "text-[var(--color-risk-high)]",
+    dotClassName: "bg-[var(--color-risk-high)]",
+    ringClassName: "ring-[var(--color-risk-high)]/40 bg-[var(--color-risk-high)]/10",
+  },
+  severe: {
+    labelKey: "legend.exposure.level.severe",
+    textClassName: "text-[var(--color-risk-extreme)]",
+    dotClassName: "bg-[var(--color-risk-extreme)]",
+    ringClassName: "ring-[var(--color-risk-extreme)]/40 bg-[var(--color-risk-extreme)]/10",
+  },
+};

--- a/apps/web/src/lib/concurrency.test.ts
+++ b/apps/web/src/lib/concurrency.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "./concurrency";
+
+describe("mapWithConcurrency", () => {
+  it("ผลลัพธ์เรียงตามลำดับ items เดิม ไม่ใช่ตามลำดับที่ตอบกลับมาก่อน-หลัง", async () => {
+    const delays = [30, 10, 20, 0];
+    const out = await mapWithConcurrency(delays, 4, async (ms, i) => {
+      await new Promise((r) => setTimeout(r, ms));
+      return i;
+    });
+    expect(out).toEqual([0, 1, 2, 3]);
+  });
+
+  it("ไม่รันเกิน limit งานพร้อมกัน", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    await mapWithConcurrency(items, 3, async (i) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+      return i;
+    });
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it("limit มากกว่าจำนวน items ก็ยังรันครบทุกตัว", async () => {
+    const out = await mapWithConcurrency([1, 2, 3], 10, async (n) => n * 2);
+    expect(out).toEqual([2, 4, 6]);
+  });
+
+  it("รายการว่าง คืน [] โดยไม่ throw", async () => {
+    const out = await mapWithConcurrency([], 5, async (n: number) => n);
+    expect(out).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/concurrency.ts
+++ b/apps/web/src/lib/concurrency.ts
@@ -1,0 +1,28 @@
+/**
+ * รัน `fn` บน `items` พร้อมกันได้สูงสุด `limit` งาน — ใช้แทนการยิง `Promise.all`
+ * ตรง ๆ ตอนที่จำนวนรายการอาจมากถึงหลักร้อย (เช่น อปท. ในจังหวัดหนึ่งที่มีขอบเขต
+ * จริง E11.2 ครบ — จังหวัดที่มากที่สุดมี ~144 รายการ) การยิงพร้อมกันหมดทุกตัวเป็น
+ * การถล่ม API/Worker โดยไม่จำเป็น ทั้งที่โควตา rate-limit เดียวกันต้องแบ่งกับ
+ * คำขออื่นของหน้าเดียวกันด้วย (observations, dams, ...)
+ *
+ * ผลลัพธ์เรียงตามลำดับ `items` เดิมเสมอ ไม่ใช่ตามลำดับที่ตอบกลับมาถึงก่อน-หลัง —
+ * ผู้เรียกจึงจับคู่ `items[i]` กับ `results[i]` ได้ตรงไปตรงมา
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const i = next;
+      next += 1;
+      results[i] = await fn(items[i], i);
+    }
+  };
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/apps/web/src/lib/localAuthorityTypeLabel.ts
+++ b/apps/web/src/lib/localAuthorityTypeLabel.ts
@@ -1,0 +1,12 @@
+import type { LocalAuthorityType } from "@siahra/shared-types";
+import type { MessageKey } from "../i18n";
+
+/** คีย์ป้ายชื่อประเภท อปท. หกชนิด — ใช้ร่วมกันทุกจุดที่แสดงประเภทของ อปท. */
+export const LOCAL_AUTHORITY_TYPE_KEY: Record<LocalAuthorityType, MessageKey> = {
+  provincial_admin_org: "localAuthority.type.provincial_admin_org",
+  city_municipality: "localAuthority.type.city_municipality",
+  town_municipality: "localAuthority.type.town_municipality",
+  subdistrict_municipality: "localAuthority.type.subdistrict_municipality",
+  subdistrict_admin_org: "localAuthority.type.subdistrict_admin_org",
+  special_admin_area: "localAuthority.type.special_admin_area",
+};


### PR DESCRIPTION
## What this does

Adds the web decision panel — impact card, ranked affected-authority list, and alert banner — consuming the real API contracts from E11.3–E11.5. No new data computation, pure UI. This is the sixth and final task of the local-authority (LAO) re-implementation planned after PR #44 reverted the fabricated version.

## Why

The reverted implementation's `ImpactSummaryCard` had a hardcoded green health dot never derived from actual source health, a hardcoded source-credit string, and hid the timestamp entirely when `fetchedAt` was null instead of saying "never fetched". Its `ActiveAlertBanner` did `if (alerts.length === 0) return null` — collapsing "evaluated, nothing active" / "API failed" / "never evaluated" into indistinguishable silence, and "never evaluated" was the actual production state at the time. Its hook never reset state on province change (switching provinces showed the previous province's numbers under the new heading) and had no `AbortController`.

## What's real, not assumed

- **Every number carries a freshness badge derived from its response's real descriptor** via the house `layerFreshness.ts` utilities — no hardcoded color anywhere.
- **Population is labelled an explicit WorldPop 2020 estimate**, never presented as a headcount.
- **Observed fields (`floodedAreaKm2`, `facilitiesExposed`) are visually distinct from illustrative, area-weighted fields (`populationExposed`, `buildingsExposed`)** — confirmed both descriptor variants actually render differently, not collapsed to one look.
- **No `confidence` badge, no THB figure** — the real API produces neither, so neither exists in the UI.
- **The candidate-authority list comes from the real E11.2 boundary geometry, not the full E11.1 registry.** The registry overstates coverage by up to ~79× per province (Songkhla: 141 registry entries vs. 2 with a real boundary) — building the list from the registry would have produced a wall of authorities that all 404 from `/impact`. Found and fixed by the implementer during its own advisor review, before any external QA pass.
- **The alert banner distinguishes four states, not three**: healthy-with-alerts, never-evaluated, full failure (no data at all), and — added in QA round 2 after the first pass missed it — **degraded**: a live refresh just failed but a prior alert list is still shown, dimmed, with a visible warning, rather than silently looking identical to a healthy state.
- **Hooks reset state on selection change, use `AbortController`, and back off exponentially on failure** (`lib/feed/backoff.ts`) — mirroring the house `useFloodExtent.ts` pattern exactly.

## QA found one real bug before this shipped

Round 1 QA (`verdict: fail`) caught that `ActiveAlertBanner`'s non-empty alert-list branch never checked the hook's `error` state — a live alert-engine outage mid-session would silently keep rendering stale alerts as current, exactly the class of bug this epic exists to eliminate. Fixed in round 2: the alert list now dims and shows a warning with the real error detail whenever a background refresh fails after data has already loaded. QA independently re-verified the fix live (forced a fetch failure, confirmed the degraded state renders distinctly from both healthy and full-failure) and passed with zero findings.

## Screenshot

Samut Prakan — 5 real active alerts (real `high`-severity stations, real trigger times) alongside the ranked affected-authority list, both rendered from live data.

![e116-samutprakan](https://github.com/flukelaster/SIAHRA/releases/download/primg-feat-local-authority-decision-panel/e116-samutprakan.png)

## Verification

- Round 1 QA: full CI gate green, live-verified three of the four alert states and the observed/illustrative distinction against real data, found the one real bug above.
- Round 2 QA: re-verified the fix by reading the actual render logic (not trusting the summary) and confirmed no leftover test scaffinding from the implementer's live-failure test; full CI gate green again; screenshot of the healthy state confirming no regression.
- `npx tsc -b` + `npx oxlint src worker` (web), `npx tsc --noEmit` (api, etl — untouched, confirmed), root `npm test` (176 web tests, plus 385 api + 78 etl unaffected).
- `npm run build -w apps/web` — 291.47 KB gzip entry+vendor, 81.0% of the 360 KB regression-guard warning (not a hard failure), 32.4% of the 900 KB roadmap ceiling.

## This closes the epic

Revert (#44) → E11.1 real DLA registry (#45) → E11.2 real OSM boundaries (#46) → E11.3 real baseline exposure (#47) → E11.4 real flood intersection (#48) → E11.5 real threshold engine (#49) → E11.6 (this PR). Every number the local-authority decision-support surface shows now traces to a real, cited, fetched source, with honest partial coverage stated rather than implied as complete.
