### PR TITLE
chore: promote Test to a required status check on main

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -27,7 +27,8 @@
         "required_status_checks": [
           { "context": "Lint", "integration_id": 15368 },
           { "context": "TypeScript", "integration_id": 15368 },
-          { "context": "Build", "integration_id": 15368 }
+          { "context": "Build", "integration_id": 15368 },
+          { "context": "Test", "integration_id": 15368 }
         ]
       }
     }

--- a/scripts/apply-branch-rules.sh
+++ b/scripts/apply-branch-rules.sh
@@ -9,7 +9,10 @@
 #   - no direct pushes: every change arrives via a pull request
 #   - no force-push, no branch deletion
 #   - required status checks (from GitHub Actions, integration_id 15368):
-#       Lint, TypeScript, Build   (.github/workflows/ci.yml)
+#       Lint, TypeScript, Build, Test   (.github/workflows/ci.yml)
+#     Test is the aggregate `if: always()` gate, not the path-filtered
+#     per-workspace legs — see ci.yml's own comment on that job for why only
+#     the aggregate is safe to require.
 #     0 approving reviews required — this is a solo-maintained repo; bump
 #     required_approving_review_count in main.json when that changes.
 #


### PR DESCRIPTION
## What this does

Promotes the `Test` job in `ci.yml` to a required status check on `main`, alongside the existing `Lint`/`TypeScript`/`Build`.

## Why

The revert of PRs #37-#43 was necessary in part because #43 merged and deployed on a red `Test` run — the check existed in `ci.yml` but was never required, so a failing test suite couldn't block a merge. This closes that gap.

`Test` is the aggregate `if: always()` gate, not the path-filtered per-workspace legs (`Test (api, apps/api)` etc.) — `ci.yml`'s own comment on that job already documents why only the aggregate is safe to require: a path-filtered leg never runs at all on a PR that doesn't touch that workspace, so requiring one directly would make such a PR wait forever.

## What changed

- `.github/rulesets/main.json` — added `Test` to `required_status_checks`.
- `scripts/apply-branch-rules.sh` — updated the header comment to match, and noted why it's the aggregate gate and not a per-workspace leg.
- Applied live via `scripts/apply-branch-rules.sh` before this PR was opened — GitHub's ruleset API confirms all four checks (`Lint`, `TypeScript`, `Build`, `Test`) are now required on `main`. This PR brings the tracked config back in sync with what's already enforced.

## Verification

`gh api repos/flukelaster/SIAHRA/rulesets/20929128` shows `required_status_checks` with all four contexts.