### PR TITLE
docs(agents): add guardrail against fabricated static-data pattern

### DIFF
--- a/.claude/agents/qa-verifier.md
+++ b/.claude/agents/qa-verifier.md
@@ -65,6 +65,28 @@ Do this when the diff touches `apps/web/index.html`, `src/App.tsx`, `src/main.ts
 - Are stale data and dead sources still visible?
 - If `packages/shared-types` changed, were all api/web/etl consumers updated?
 
+### 3a. Fabricated static-data gate — this repo reverted PRs #37–#43 for exactly this
+```
+git diff HEAD --name-only --diff-filter=AM -- 'apps/api/src/data/*.ts' | grep -v '\.test\.ts$'
+```
+For each file this lists, open it and check:
+- **Does it import a sibling `.json`** (`import raw from "./X.json"`) rather than embedding values
+  itself? That is the honest bake-into-bundle pattern this repo already uses
+  (`localAuthorities.ts`, `provinceRings.ts`, `localAuthorityExposure.ts`, `alertRules.json`'s
+  loader) — real numbers, produced by a real `apps/etl` script. Fine, move on.
+- **If instead the numbers are typed directly into the `.ts` file** (a literal array/object with
+  several numeric fields) **and** the file also builds or exports a `HazardLayerDescriptor` /
+  claims a `sourceIds` entry, that is the PR #37–#43 shape verbatim — hand-typed measurements
+  wearing a provenance claim. Confirm there is a real source behind it:
+  ```
+  grep -rl "<the sibling .json name, or the .ts file's own basename>" apps/etl/src/*.ts
+  ls apps/etl/data/sources/*/SOURCE.md apps/etl/data/sources/*/COVERAGE.md 2>/dev/null
+  ```
+  No ETL script produces the data and no `SOURCE.md`/`COVERAGE.md` documents where the numbers
+  came from → this is a **blocker**, not a minor, whatever else the diff does right. Quote the
+  literal values in your finding, not just the file name — the reviewer needs to see the fabricated
+  numbers directly, the same way this pattern was caught the first time.
+
 ## 4. Check each `acceptance_criteria` entry you were given, one by one
 
 ## Output — a single JSON object, nothing wrapped around it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,12 @@ below is the human-facing explanation of the same thing. Mechanical checks stay 
 - The same-origin guard or rate limiting in `apps/api/src/router.ts` weakened or bypassed; a
   Durable Object / R2 change that loses or corrupts stored observations; a leaked credential; a
   `wrangler.jsonc`, route or binding change that breaks a deploy
+- A hand-typed numeric-literal array or object in `apps/api/src/data/*.ts` (or a similar
+  hardcoded-data file elsewhere) that claims a `HazardLayerDescriptor`/`sourceIds`/provenance —
+  with no `apps/etl` build script producing it and no `SOURCE.md`/coverage doc behind it. This is
+  the exact shape of PRs #37–#43, reverted once already for fabricating measured data this way;
+  a file importing a sibling `.json` baked by a real ETL script (`localAuthorities.ts`,
+  `provinceRings.ts`) is the honest version of this pattern and is not this rule
 
 ### P2 — non-blocking; same comment, never its own thread
 These are the only non-blocking findings worth a comment. They go under `### Minor / optional` at
@@ -114,6 +120,9 @@ correct.
 - Same-origin guard or rate limiting in `apps/api/src/router.ts` weakened or bypassed
 - Durable Object / R2 change that loses or corrupts stored observations
 - Config change that breaks a deploy (`wrangler.jsonc`, routes, bindings, environments)
+- A hand-typed numeric literal array/object in `apps/api/src/data/*.ts` claiming a
+  `HazardLayerDescriptor`/`sourceIds`, with no `apps/etl` build script and no `SOURCE.md` behind
+  it (the PRs #37–#43 pattern) — a file importing a sibling `.json` a real ETL script wrote is fine
 
 **P2 — non-blocking; goes under `### Minor / optional` in that same comment, never its own thread**
 - Error handling that swallows failures instead of surfacing them


### PR DESCRIPTION
## What this does
Adds a P1 review rule (in both `AGENTS.md` review-rule lists) and a matching mechanical
grep gate in `qa-verifier.md` that catches the exact shape of the fabricated data
reverted in PRs #37-#43: a hand-typed numeric literal array/object in
`apps/api/src/data/*.ts` that claims a `HazardLayerDescriptor`/`sourceIds` provenance
claim with no `apps/etl` build script and no `SOURCE.md`/`COVERAGE.md` behind it.

The honest bake-into-bundle pattern this repo already uses elsewhere - a `.ts` file
that imports a sibling `.json` produced by a real `apps/etl` script (`localAuthorities.ts`,
`provinceRings.ts`, `localAuthorityExposure.ts`) - is explicitly exempted so the rule
does not flag the pattern the E11 re-implementation itself relies on.

## Why
PRs #37-#43 shipped ~5,400 lines of hand-typed constants (population counts, threshold
levels, damage curves, station IDs) labelled as `observed`/`static-reference` data with
fake `sourceIds`, and were merged and deployed to prod same-day with zero review
friction. They were fully reverted (#44) and re-implemented from real sources as epic
E11 (#45-#50). This guardrail makes the next reviewer - human or Codex - stop on the
same pattern before it ships again, and gives `qa-verifier` a concrete command sequence
instead of relying on it noticing by inspection alone.

## Verification
- Self-tested the new grep gate against the 4 real `apps/api/src/data/*.ts` files
  currently in the repo (`localAuthorities.ts`, `localAuthorityExposure.ts`,
  `localAuthorityBoundaries.ts`, `alertRules.ts`): all four import a sibling `.json`,
  none embed `sourceIds` claims directly - zero false positives.
- Docs-only change, no code touched; no build/test/lint impact.
