### PR TITLE
perf(api): stop /health from scanning the station tables on every poll

### DIFF
--- a/apps/api/src/durable-objects/observation-cache.ts
+++ b/apps/api/src/durable-objects/observation-cache.ts
@@ -586,6 +586,7 @@ export class ObservationCacheDO extends DurableObject<Env> {
      */
     if (rainfall) this.replaceRainfall(rainfall);
     if (waterlevel) this.replaceWaterLevel(waterlevel);
+    if (rainfall || waterlevel) this.recomputeStationStats();
 
     // Keep the two station feeds independently auditable.  `fetchedAt` and
     // `lastError` below remain the aggregate source state, while these fields
@@ -629,6 +630,49 @@ export class ObservationCacheDO extends DurableObject<Env> {
       rainfall: rainfall?.length ?? "failed",
       waterlevel: waterlevel?.length ?? "failed",
     });
+  }
+
+  /**
+   * จำนวนสถานีและเวลาตรวจวัดใหม่สุดของสองตารางสถานี — คำนวณ **ครั้งเดียวต่อรอบ
+   * refresh** แล้วเก็บลง `meta` ให้ `status()` อ่าน ไม่ใช่ให้ `status()` นับเอง
+   *
+   * ทำไม: `/api/v1/health` ถูก poll ทุก 60 วิจากทุกแท็บที่เปิดค้าง และ `status()`
+   * เคยยิง `COUNT(*)` กับ `MAX(observed_at)` รวมห้าคำสั่งต่อครั้ง ≈ 18,000 แถวที่
+   * ถูกสแกน Cloudflare คิดเงิน rows read ตามแถวที่สแกน จึงกลายเป็น ~540M แถว/วัน
+   * จากข้อมูลที่เปลี่ยนเพียงทุก 5 นาที ค่าที่เก็บไว้นี้ยังคงมาจากตารางจริงทุกค่า —
+   * แค่ถูกวัดตอนที่ตารางเปลี่ยน ไม่ใช่ตอนที่มีคนถาม
+   *
+   * อ่านผ่าน `stationStats()` ซึ่งจะคำนวณให้หนึ่งครั้งถ้า meta ยังไม่มี (แคชที่
+   * สร้างก่อนโค้ดนี้ดีพลอย) — ไม่มีทางที่ค่าจะถูกรายงานเป็น 0/null ทั้งที่ตารางมีของ
+   */
+  private recomputeStationStats(): void {
+    const sql = this.ctx.storage.sql;
+    const rainCount = sql.exec<{ n: number }>("SELECT COUNT(*) AS n FROM rainfall").toArray()[0]?.n ?? 0;
+    const waterCount = sql.exec<{ n: number }>("SELECT COUNT(*) AS n FROM waterlevel").toArray()[0]?.n ?? 0;
+    const latestRainfall =
+      sql.exec<{ t: string | null }>("SELECT MAX(observed_at) AS t FROM rainfall").toArray()[0]?.t ?? null;
+    const latestWaterlevel =
+      sql.exec<{ t: string | null }>("SELECT MAX(observed_at) AS t FROM waterlevel").toArray()[0]?.t ?? null;
+    this.writeMeta("statRainfallCount", String(rainCount));
+    this.writeMeta("statWaterlevelCount", String(waterCount));
+    this.writeMeta("statLatestRainfall", latestRainfall);
+    this.writeMeta("statLatestWaterlevel", latestWaterlevel);
+    this.writeMeta("statStationsComputed", "1");
+  }
+
+  private stationStats(): {
+    rainCount: number;
+    waterCount: number;
+    latestRainfall: string | null;
+    latestWaterlevel: string | null;
+  } {
+    if (this.readMeta("statStationsComputed") !== "1") this.recomputeStationStats();
+    return {
+      rainCount: Number(this.readMeta("statRainfallCount") ?? "0"),
+      waterCount: Number(this.readMeta("statWaterlevelCount") ?? "0"),
+      latestRainfall: this.readMeta("statLatestRainfall"),
+      latestWaterlevel: this.readMeta("statLatestWaterlevel"),
+    };
   }
 
   /**
@@ -1100,22 +1144,12 @@ export class ObservationCacheDO extends DurableObject<Env> {
         .filter(Boolean)
         .join("; ")
         .slice(0, 300) || null;
-    const rainCount =
-      this.ctx.storage.sql.exec<{ n: number }>("SELECT COUNT(*) AS n FROM rainfall").toArray()[0]?.n ?? 0;
-    const waterCount =
-      this.ctx.storage.sql.exec<{ n: number }>("SELECT COUNT(*) AS n FROM waterlevel").toArray()[0]?.n ?? 0;
-    const latest =
-      this.ctx.storage.sql
-        .exec<{ t: string | null }>(
-          "SELECT MAX(observed_at) AS t FROM (SELECT observed_at FROM rainfall UNION ALL SELECT observed_at FROM waterlevel)",
-        )
-        .toArray()[0]?.t ?? null;
-    const latestRainfall =
-      this.ctx.storage.sql.exec<{ t: string | null }>("SELECT MAX(observed_at) AS t FROM rainfall").toArray()[0]?.t ??
-      null;
-    const latestWaterlevel =
-      this.ctx.storage.sql.exec<{ t: string | null }>("SELECT MAX(observed_at) AS t FROM waterlevel").toArray()[0]?.t ??
-      null;
+    // ค่าเหล่านี้ถูกวัดจากตารางตอนจบรอบ refresh (ดู `recomputeStationStats`) —
+    // `status()` เองต้องไม่สแกนตารางสถานี เพราะมันถูกเรียกทุกนาทีจากทุกแท็บ
+    const { rainCount, waterCount, latestRainfall, latestWaterlevel } = this.stationStats();
+    // MAX ของสองตารางรวมกัน = ค่าที่มากกว่าของ MAX แต่ละตาราง (เทียบสตริง ISO ได้ตรง ๆ
+    // เพราะ observed_at เก็บเป็น ISO-8601 UTC ความยาวเท่ากัน เหมือนที่ SQLite เทียบ)
+    const latest = [latestRainfall, latestWaterlevel].filter((t): t is string => t !== null).sort().at(-1) ?? null;
     const rainfallFetchedAt = this.readMeta("rainfallFetchedAt");
     const waterlevelFetchedAt = this.readMeta("waterlevelFetchedAt");
     const rainfallError = this.readMeta("rainfallError");

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -16,7 +16,27 @@ import type { AppEnv } from "../types.js";
  * it. Each DO reports its own status; a DO that throws is reported as
  * "unknown" rather than failing the whole endpoint.
  */
-export async function handleHealth(_request: Request, env: AppEnv): Promise<Response> {
+export async function handleHealth(request: Request, env: AppEnv, _params: string[], ctx: ExecutionContext): Promise<Response> {
+  /**
+   * แคชที่ขอบ (Cache API) 15 วินาที — เท่ากับ `max-age=15` ที่ประกาศให้เบราว์เซอร์
+   * อยู่แล้ว แต่เบราว์เซอร์ส่ง `cache: "no-store"` มา (ตั้งใจ: แถบสถานะห้ามโชว์
+   * ของค้าง) และ Worker บน `/api/*` รันทุกคำขอ ดังนั้นถ้าไม่ใส่ไว้ตรงนี้ ทุกแท็บ
+   * ที่เปิดค้างจะแตกเป็น 6 DO call ต่อนาทีต่อแท็บ — วัดจริง 2026-08-23: ~30k
+   * คำขอ/วันคูณ 6 DO = DO requests เกินโควตา และ rows read หลักร้อยล้าน/วัน
+   *
+   * ความสดของข้อมูลไม่เสีย: สถานะทุกแหล่งขยับเป็นนาที (รอบสั้นสุดคือแผ่นดินไหว
+   * 1 นาที) ของค้างสูงสุด 15 วิ จึงเล็กกว่าหนึ่งรอบของทุกแหล่ง และคำตอบที่ถูกแคช
+   * ยังมี `serverTime` ของตอนที่คำนวณอยู่ในตัว — ไม่มี `fetchedAt` ไหนถูกประทับใหม่
+   *
+   * ใช้เฉพาะ GET/HEAD (router ส่ง HEAD มาเป็น GET อยู่แล้ว) และคีย์คือ URL ล้วน —
+   * คำขอที่ผ่านกำแพง same-origin มาได้ทุกอันเห็นคำตอบเดียวกัน ไม่มีอะไรต่อผู้ใช้
+   * ในคำตอบนี้ให้รั่ว
+   */
+  const cache = caches.default;
+  const cacheKey = new Request(new URL(request.url).toString(), { method: "GET" });
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
   const collectors: Promise<SourceStatus[]>[] = [
     env.OBSERVATION_CACHE.getByName("thaiwater")
       .status()
@@ -55,7 +75,9 @@ export async function handleHealth(_request: Request, env: AppEnv): Promise<Resp
     sources,
     api: { rateLimited429LastHour: rejectedLastHour() },
   };
-  return json(body, { cache: cachePolicy.health });
+  const res = json(body, { cache: cachePolicy.health });
+  ctx.waitUntil(cache.put(cacheKey, res.clone()));
+  return res;
 }
 
 /**

--- a/apps/api/test/healthRowsRead.test.ts
+++ b/apps/api/test/healthRowsRead.test.ts
@@ -1,0 +1,91 @@
+import { env, exports as workerExports } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../src/types";
+
+/**
+ * `/api/v1/health` ถูก poll ทุก 60 วิจากทุกแท็บที่เปิดค้าง และ `status()` ของ
+ * ObservationCacheDO เคยสแกนสองตารางสถานี (~6,000 แถว) ห้าคำสั่งต่อครั้ง —
+ * วัดจริง 2026-08-23 ≈ 540M rows read/วัน จากข้อมูลที่เปลี่ยนแค่ทุก 5 นาที
+ * เทสนี้ตรึงสองอย่าง: (1) `status()` อ่านค่าที่วัดไว้ตอน refresh ไม่ได้นับสด และ
+ * (2) คำตอบของ /health ถูกแคชที่ขอบในหน้าต่าง 15 วิ
+ */
+
+const appEnv = env as unknown as AppEnv;
+const stub = () => appEnv.OBSERVATION_CACHE.getByName("thaiwater");
+
+interface Internals {
+  recomputeStationStats(): void;
+}
+
+async function seedRainfall(ids: number[], observedAt: string): Promise<void> {
+  await runInDurableObject(stub(), (_instance, state) => {
+    for (const id of ids) {
+      state.storage.sql.exec(
+        "INSERT OR REPLACE INTO rainfall (station_id, province_code, rain_24h, observed_at, payload) VALUES (?, ?, ?, ?, ?)",
+        id,
+        "10",
+        1,
+        observedAt,
+        JSON.stringify({ station: { id, provinceCode: "10" }, rain24h: 1, observedAt }),
+      );
+    }
+  });
+}
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+    throw new Error("network disabled in this test");
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ObservationCacheDO.status() ไม่สแกนตารางสถานี", () => {
+  it("รายงานค่าที่วัดไว้ตอน refresh — แถวที่เข้ามาหลังจากนั้นไม่ถูกนับจนกว่าจะวัดใหม่", async () => {
+    await seedRainfall([1, 2], "2026-08-23T12:00:00.000Z");
+    await runInDurableObject(stub(), (instance) => {
+      (instance as unknown as Internals).recomputeStationStats();
+    });
+    const before = await stub().status();
+    expect(before.detail.rainfallStations).toBe(2);
+
+    // แถวที่สามเขียนตรงเข้าตาราง โดยไม่ผ่านรอบ refresh
+    await seedRainfall([3], "2026-08-23T13:00:00.000Z");
+    const stale = await stub().status();
+    expect(stale.detail.rainfallStations).toBe(2);
+    expect(stale.latestObservedAt).toBe("2026-08-23T12:00:00.000Z");
+
+    await runInDurableObject(stub(), (instance) => {
+      (instance as unknown as Internals).recomputeStationStats();
+    });
+    const after = await stub().status();
+    expect(after.detail.rainfallStations).toBe(3);
+    expect(after.latestObservedAt).toBe("2026-08-23T13:00:00.000Z");
+  });
+
+  it("แคชที่สร้างก่อนโค้ดนี้ (ไม่มี meta) ถูกวัดให้หนึ่งครั้ง ไม่รายงาน 0 ทั้งที่ตารางมีของ", async () => {
+    await seedRainfall([7], "2026-08-23T12:00:00.000Z");
+    await runInDurableObject(stub(), (_instance, state) => {
+      state.storage.sql.exec("DELETE FROM meta WHERE key LIKE 'stat%'");
+    });
+    const s = await stub().status();
+    expect(s.detail.rainfallStations).toBeGreaterThanOrEqual(1);
+    expect(s.latestObservedAt).not.toBeNull();
+  });
+});
+
+describe("GET /api/v1/health ถูกแคชที่ขอบ", () => {
+  it("สองคำขอติดกันได้คำตอบเดียวกัน (serverTime เท่ากัน) และไม่ยิง DO ซ้ำ", async () => {
+    const url = "https://siahra-radar.co/api/v1/health?t=edge-cache";
+    const first = await workerExports.default.fetch(new Request(url));
+    expect(first.status).toBe(200);
+    const a = (await first.json()) as { serverTime: string };
+    const second = await workerExports.default.fetch(new Request(url));
+    const b = (await second.json()) as { serverTime: string };
+    expect(b.serverTime).toBe(a.serverTime);
+    expect(second.headers.get("Cache-Control")).toBe("public, max-age=15");
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #53. With the per-station history scans gone, the largest remaining source of Durable Object rows read is `GET /api/v1/health`:

- `ObservationCacheDO.status()` ran **five aggregate statements per call** — `COUNT(*)` on `rainfall` and `waterlevel`, plus three `MAX(observed_at)` — over ~6,000 station rows, i.e. ~18k rows scanned per call.
- The web app polls `/health` every 60 s per open tab with `cache: "no-store"`, and the Worker on `/api/*` runs on every request, so the declared `Cache-Control: public, max-age=15` never collapsed anything.
- Measured 2026-08-23: ~30k calls/day × ~18k rows ≈ **540M rows read/day ≈ 16B/month**, roughly three quarters of the 25B/month included allowance, for data that only changes on the 5-minute refresh. Each call also fanned out to 6 DO requests, which is why DO requests (1.26M) were already past their 1M included quota.

Target after this PR is comfortably inside the included allowances (rows read ≈ 2–3B/month, DO requests well under 1M), i.e. a $0 Durable Objects line.

## What changed

`apps/api/src/durable-objects/observation-cache.ts`
- `recomputeStationStats()` measures the two counts and two latest observation times **once at the end of each refresh** (only when at least one feed succeeded, since that is the only time the tables change) and stores them in `meta`.
- `status()` reads those stored values; the combined `latestObservedAt` is the greater of the two per-table maxima (ISO-8601 UTC strings of equal length, so string order is time order — the same comparison SQLite made).
- A cache that predates this code has no stat keys: `stationStats()` measures once on first read. Nothing is ever reported as `0`/`null` while the table has rows.

`apps/api/src/routes/health.ts`
- `handleHealth` serves from `caches.default` within the 15 s window its own cache policy already declares, and writes the fresh response back via `ctx.waitUntil`. Key is the bare URL; the response has nothing per-user. HEAD is already dispatched as GET by the router, and the security headers are applied at the router exit on both the fresh and the cached path.

Data honesty is unchanged: the cached body carries the `serverTime` it was computed at, no `fetchedAt` is restamped, and 15 s is shorter than the fastest source cadence (earthquakes, 1 min), so no status can be more than a fraction of one cycle behind.

## Verification

- `npx tsc --noEmit`, `npx tsc -p test/tsconfig.json --noEmit` in `apps/api`
- `npm run test -w apps/api` — 42 files, 394 tests passing
- New `apps/api/test/healthRowsRead.test.ts`: `status()` reports the values measured at refresh time and does not see rows inserted behind its back until the next measurement; a pre-existing cache without stat keys is measured once; two back-to-back `/health` requests return the same `serverTime` with the 15 s cache header.

No UI change, hence `no-screenshot`.
