### PR TITLE
chore: guard Durable Object rows read against the #53/#54 pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,15 @@ below is the human-facing explanation of the same thing. Mechanical checks stay 
   the exact shape of PRs #37–#43, reverted once already for fabricating measured data this way;
   a file importing a sibling `.json` baked by a real ETL script (`localAuthorities.ts`,
   `provinceRings.ts`) is the honest version of this pattern and is not this rule
+- **A Durable Object SQL statement that scans a table on a per-request or per-item path.** DO rows
+  read are billed by rows *scanned*, not returned — an aggregate (`COUNT`, `MAX`), an unindexed
+  `WHERE`/`ORDER BY`, or a retention `DELETE` that runs inside a request handler, a `status()`, or a
+  loop over stations/provinces is this finding, however small the table looks today. The 2026-08-18..23
+  bill was 72B rows read on 64 MB of storage from exactly two such statements. Whole-table reads are
+  acceptable only once per refresh/alarm tick or once an hour, and every one of them must be listed
+  with its reason in `ALLOWED_SCANS` of `apps/api/test/sqlQueryPlans.test.ts` — a new statement that
+  scans and is not listed there fails that test, so a PR that adds a scan must also add the entry,
+  and the entry's reason is what this review checks
 
 ### P2 — non-blocking; same comment, never its own thread
 These are the only non-blocking findings worth a comment. They go under `### Minor / optional` at
@@ -123,6 +132,11 @@ correct.
 - A hand-typed numeric literal array/object in `apps/api/src/data/*.ts` claiming a
   `HazardLayerDescriptor`/`sourceIds`, with no `apps/etl` build script and no `SOURCE.md` behind
   it (the PRs #37–#43 pattern) — a file importing a sibling `.json` a real ETL script wrote is fine
+- A Durable Object SQL statement that scans a table on a per-request or per-item path (rows read are
+  billed by rows *scanned*): aggregates, unindexed filters, or retention deletes inside a request
+  handler, `status()`, or a per-station/per-province loop. Whole-table reads belong on the
+  refresh/alarm path only and must be listed with a reason in `ALLOWED_SCANS`
+  (`apps/api/test/sqlQueryPlans.test.ts`)
 
 **P2 — non-blocking; goes under `### Minor / optional` in that same comment, never its own thread**
 - Error handling that swallows failures instead of surfacing them

--- a/apps/api/test/raw-modules.d.ts
+++ b/apps/api/test/raw-modules.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Vite's `?raw` import (the file's text as a string) — used by
+ * `sqlQueryPlans.test.ts` to read the Durable Object sources. The test tsconfig
+ * is the only project that includes this file, so the Worker build never sees it.
+ */
+declare module "*?raw" {
+  const text: string;
+  export default text;
+}

--- a/apps/api/test/sqlQueryPlans.test.ts
+++ b/apps/api/test/sqlQueryPlans.test.ts
@@ -1,0 +1,116 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { AppEnv } from "../src/types";
+import alertEngineSrc from "../src/durable-objects/alert-engine.ts?raw";
+import earthquakeSrc from "../src/durable-objects/earthquake-feed.ts?raw";
+import floodSrc from "../src/durable-objects/flood-extent.ts?raw";
+import observationSrc from "../src/durable-objects/observation-cache.ts?raw";
+import radarSrc from "../src/durable-objects/radar.ts?raw";
+
+/**
+ * กันบิล Durable Objects แบบ 2026-08-18..23 (72B rows read บนสตอเรจ 64 MB) ไม่ให้
+ * กลับมา: Cloudflare คิดเงิน rows read ตามแถวที่ถูก **สแกน** ไม่ใช่แถวที่ถูกคืน
+ * ดังนั้นทุก SQL literal ในโค้ด DO ถูกดึงออกมาแล้วถาม SQLite ตัวจริง (ผ่าน
+ * `EXPLAIN QUERY PLAN` บน schema ที่ constructor สร้าง) ว่ามันจะ `SCAN` ทั้งตาราง
+ * หรือไม่ — คำสั่งที่สแกนต้องอยู่ใน allowlist ข้างล่างพร้อมเหตุผลว่าทำไมถึงรับได้
+ * (วิ่งบนเส้นทาง refresh ที่นาน ๆ ครั้ง หรือตารางเล็กจนไม่มีความหมาย) ไม่ใช่ผ่าน
+ * เงียบ ๆ เพราะ "มันก็ทำงานได้"
+ *
+ * เกณฑ์ตัดสินว่า SCAN รับได้หรือไม่ อยู่ที่ **เส้นทางที่เรียกมัน** ไม่ใช่ตัวคำสั่ง:
+ * - รับได้: เรียกครั้งเดียวต่อรอบ refresh/alarm (ทุก 1–30 นาที) หรือรายชั่วโมง
+ * - รับไม่ได้: เรียกต่อคำขอ HTTP (`/health`, `/observations`, …) หรือต่อรายการใน
+ *   ลูป (ต่อสถานี ต่อจังหวัด) — นี่คือสองรูปแบบที่พาไปถึง 72B
+ * ถ้าเพิ่มคำสั่งใหม่แล้วเทสนี้แดง: ใส่ดัชนีให้มัน หรือย้ายมันไปเส้นทาง refresh
+ * แล้วค่อย allowlist พร้อมเหตุผล
+ */
+
+const appEnv = env as unknown as AppEnv;
+
+interface DoSource {
+  label: string;
+  source: string;
+  stub: () => { fetch?: unknown };
+}
+
+const SOURCES: DoSource[] = [
+  { label: "ObservationCacheDO", source: observationSrc, stub: () => appEnv.OBSERVATION_CACHE.getByName("plan-test") },
+  { label: "FloodExtentDO", source: floodSrc, stub: () => appEnv.FLOOD_EXTENT.getByName("plan-test") },
+  { label: "RadarDO", source: radarSrc, stub: () => appEnv.RADAR.getByName("plan-test") },
+  { label: "EarthquakeFeedDO", source: earthquakeSrc, stub: () => appEnv.EARTHQUAKE_FEED.getByName("plan-test") },
+  { label: "AlertEngineDO", source: alertEngineSrc, stub: () => appEnv.ALERT_ENGINE.getByName("plan-test") },
+];
+
+/**
+ * คำสั่งที่สแกนทั้งตารางโดยตั้งใจ — คีย์คือ SQL ทั้งประโยค เหตุผลคือค่า
+ * ทุกตัวในนี้วิ่งบนเส้นทาง refresh/alarm หรือรายชั่วโมง ไม่ใช่ต่อคำขอหรือต่อรายการ
+ */
+const ALLOWED_SCANS: Record<string, string> = {
+  // ObservationCacheDO — รอบ refresh ทุก 5 นาที: ต้องอ่านทั้งตารางเพื่อเทียบ observedAt
+  "SELECT station_id, observed_at FROM rainfall": "replaceRainfall(): once per 5-min refresh, diffs the whole feed",
+  "SELECT station_id, observed_at FROM waterlevel": "replaceWaterLevel(): once per 5-min refresh, diffs the whole feed",
+  "SELECT COUNT(*) AS n FROM rainfall": "recomputeStationStats(): once per refresh, result cached in meta for status()",
+  "SELECT COUNT(*) AS n FROM waterlevel": "recomputeStationStats(): once per refresh, result cached in meta for status()",
+  "SELECT MAX(observed_at) AS t FROM rainfall": "recomputeStationStats(): once per refresh, result cached in meta",
+  "SELECT MAX(observed_at) AS t FROM waterlevel": "recomputeStationStats(): once per refresh, result cached in meta",
+  "SELECT payload FROM rainfall": "nationwide getObservations()/publishExposure(): the whole table IS the answer",
+  "SELECT payload FROM waterlevel": "nationwide getObservations()/publishExposure(): the whole table IS the answer",
+  "SELECT station_id, province_code FROM waterlevel": "archiveDay(): once per day",
+  "SELECT payload FROM dams": "dams table is ~12 rows",
+  "DELETE FROM dams": "dams table is ~12 rows, rewritten every 30 min",
+  "DELETE FROM archive_cache WHERE fetched_ms < ?": "archive_cache holds a handful of rows, pruned on the archive path",
+  // EarthquakeFeedDO — ตาราง events ≤ 30 วัน (~200 แถว) และทุกคำสั่งวิ่งบน poll ทุกนาที
+  "SELECT COUNT(*) AS n FROM events": "events is ~200 rows; status() of a 1-minute poller",
+  "SELECT MAX(time_ms) AS newest, MAX(updated_ms) AS published FROM events": "events is ~200 rows",
+  "SELECT MAX(time_ms) AS t FROM events": "events is ~200 rows",
+  "SELECT * FROM events ORDER BY time_ms DESC LIMIT ?": "events is ~200 rows; the LIMIT keeps the answer small",
+  "SELECT * FROM events ORDER BY time_ms DESC LIMIT 200": "events is ~200 rows",
+  "SELECT * FROM events WHERE mag >= ? ORDER BY time_ms DESC LIMIT ?": "events is ~200 rows",
+  "SELECT id, lat, lon FROM events WHERE nearest IS NULL OR json_valid(nearest) = 0 LIMIT ?": "backfill on the poll path, events is ~200 rows",
+  "DELETE FROM events WHERE time_ms < ?": "once per poll, events is ~200 rows",
+  // RadarDO — frames ≤ 24 h (~65 แถว)
+  "SELECT MAX(ts_ms) AS t FROM frames": "frames is ~65 rows",
+  "SELECT ts_ms, key FROM frames WHERE ts_ms < ?": "retention on the refresh path, frames is ~65 rows",
+  "SELECT COUNT(*) AS n FROM frames WHERE ts_ms >= ?": "frames is ~65 rows",
+  "SELECT ts_ms, key FROM frames WHERE ts_ms >= ? ORDER BY ts_ms ASC": "frames is ~65 rows; PK order",
+  // AlertEngineDO — rule_state มี ~300 แถว อ่านบนรอบประเมิน 5 นาที
+  "SELECT MAX(last_observed_at) AS v FROM rule_state": "rule_state is ~300 rows; status()",
+};
+
+/** ดึง SQL literal แบบ static ออกจากซอร์ส — INSERT ที่ประกอบ placeholder ข้ามไป (ไม่มีทางสแกน) */
+function sqlLiterals(source: string): string[] {
+  const out = new Set<string>();
+  for (const m of source.matchAll(/"((?:SELECT|DELETE|UPDATE)\b[^"]*)"/g)) out.add(m[1]!);
+  return [...out];
+}
+
+describe("ทุก SQL literal ใน Durable Objects ใช้ดัชนี หรืออยู่ใน allowlist พร้อมเหตุผล", () => {
+  for (const { label, source, stub } of SOURCES) {
+    it(label, async () => {
+      const statements = sqlLiterals(source);
+      expect(statements.length).toBeGreaterThan(0);
+      const offenders: string[] = [];
+      await runInDurableObject(stub() as never, (_instance, state) => {
+        for (const sql of statements) {
+          // bind ค่า dummy ให้ครบทุก `?` — แผนไม่ขึ้นกับค่า แต่ workerd ตรวจจำนวน
+          const binds = Array.from({ length: (sql.match(/\?/g) ?? []).length }, () => 0);
+          const plan = state.storage.sql
+            .exec<{ detail: string }>(`EXPLAIN QUERY PLAN ${sql}`, ...binds)
+            .toArray()
+            .map((r) => r.detail)
+            .join(" | ");
+          // "SCAN <table>" โดยไม่มี "USING INDEX/COVERING INDEX" ต่อท้าย = อ่านทุกแถว
+          const fullScan = /\bSCAN \w+(?! USING (?:COVERING )?INDEX)/.test(plan);
+          if (fullScan && !(sql in ALLOWED_SCANS)) offenders.push(`${sql}\n    plan: ${plan}`);
+        }
+      });
+      expect(offenders, `full-table scans not in ALLOWED_SCANS:\n  ${offenders.join("\n  ")}`).toEqual([]);
+    });
+  }
+
+  it("allowlist ไม่มีรายการค้างที่โค้ดเลิกใช้แล้ว", () => {
+    const all = new Set(SOURCES.flatMap((s) => sqlLiterals(s.source)));
+    const orphans = Object.keys(ALLOWED_SCANS).filter((sql) => !all.has(sql));
+    expect(orphans).toEqual([]);
+  });
+});

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -62,6 +62,7 @@ curl -s .../api/v1/health | jq --arg now "$(date -u +%FT%TZ)" '
 | `unknown` on a fresh deploy | No attempt has produced a result yet | Wait one cron tick (1 min). If it persists, the DO is throwing before it records anything — check `wrangler tail` (§3). |
 | API answers `500`/`503` broadly, health itself errors | Durable Objects quota (see §7) or a bad deploy | `wrangler tail`, then roll back (§8) if a deploy caused it. |
 | `429` with `Retry-After` for a normal client | Per-route rate limit tripped (`apps/api/src/index.ts` route table) | Check `api.rateLimited429LastHour`. Limits are per isolate and per client IP; a single client can only starve itself. |
+| **Durable Objects "SQL rows read" climbing by billions a day** while "Total SQL storage" stays in the tens of MB | A statement that scans a whole table is running per request or per item (the 2026-08-18..23 incident: a retention `DELETE` per station pull + five aggregates per `/health`) | §9. Do not wait for the billing page — it lags a day; read the counter on **Workers & Pages → Durable Objects**. |
 | Map loads but radar/tiles are missing | R2 object missing or the tile route is wrong | For radar: check `detail.skippedFrames` on the `tmd-radar` source in `/api/v1/health`. For tiles: see `docs/deploy.md` §2. |
 
 ## 3. Reading the logs
@@ -302,3 +303,35 @@ Notes before you press it:
 - Rollback does not touch R2 or secrets.
 - After rolling back, confirm with `curl -s .../api/v1/health | jq '.ok, .worst'` and one real data
   route; `ok: false` right after a rollback is normal for a minute while each DO re-fetches.
+
+## 9. Durable Object rows read — finding what scans
+
+Rows read are billed by rows **scanned**, not returned (D1/DO pricing), so a small, quiet database
+can bill billions: 2026-08-18..23 was 72.38B rows read on 64.57 MB of storage — $1 per billion past
+the 25B included per cycle. The two statements responsible were a retention `DELETE … WHERE ts_ms < ?`
+at the end of a per-station history pull (PK is `(station_id, ts_ms)`, so `ts_ms` alone cannot use
+it → full scan, × 24 stations per province view) and five `COUNT`/`MAX` aggregates inside
+`ObservationCacheDO.status()`, which `/health` calls once a minute per open tab. Fixed in #53 and #54.
+
+**Where to look, in order**
+1. **Workers & Pages → Durable Objects** (dashboard): the usage tiles are live; the billing page
+   lags ~a day. Note the number and the time, come back in 30 min — after the fixes the counter
+   moves by ~0.01B every few hours, not every minute. Per-namespace `Requests` on the same page shows
+   which DO is being hit.
+2. **Find the statement**: copy the DO's SQLite file out of a dev worktree
+   (`apps/api/.wrangler/state/v3/do/siahra-api-<DO>/*.sqlite`) and run `EXPLAIN QUERY PLAN` on each
+   suspect statement with `sqlite3`. `SCAN <table>` with no `USING INDEX` = every row is read.
+   `apps/api/test/sqlQueryPlans.test.ts` does exactly this for every static SQL literal in
+   `src/durable-objects/*.ts` and fails on any scan that is not in its `ALLOWED_SCANS` list with a
+   reason, so a new offender normally never reaches `main`.
+3. **Then ask how often it runs.** A scan once per 5-minute refresh is fine; the same scan inside a
+   request handler, `status()`, or a loop over stations is the bug. Fix by (a) adding the index the
+   predicate needs, (b) moving the statement onto the refresh/alarm path and caching its result in
+   `meta`, or (c) rate-gating it (`pruneRetention()` runs at most hourly) — then list any remaining
+   whole-table read in `ALLOWED_SCANS` with the reason.
+4. **Set a budget alert** once: Durable Objects page → *Add Budget Alert* on the billing card. This
+   is a one-time dashboard action, not something the repo can enforce.
+
+**Included per cycle on Workers Paid** (2026-08): 25B rows read, 50M rows written, 1M DO requests,
+400k GB-s. The post-#54 steady state is ≈ 80M rows read/day (≈ 2.4B/cycle, ~10% of the allowance)
+and well under the request quota; anything an order of magnitude above that is a regression.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -52,6 +52,7 @@ Version notes that cost time to rediscover (they are also in `apps/api/vitest.co
 | `test/upstreamShape.test.ts`, `test/upstreamShapeDurableObjects.test.ts` | Malformed payloads (`{}`, `[]`, truncated JSON) are **rejected** and never overwrite stored data |
 | `test/ingestion/*.test.ts` | **Normalisation**: raw payload → our types, per upstream (units, timezones, ids, nulls) |
 | `test/sourceStatus.test.ts`, `test/scheduledTick.test.ts`, `test/cachePolicy.test.ts`, … | Freshness ladder, cron orchestration, cache policy, archive keys |
+| `test/sqlQueryPlans.test.ts`, `test/historyRetention.test.ts`, `test/healthRowsRead.test.ts` | **Rows-read guard**: every static SQL literal in `src/durable-objects/*.ts` is run through `EXPLAIN QUERY PLAN` on the real schema and may only full-scan if it is listed in `ALLOWED_SCANS` with a reason; retention stays off the per-station path; `status()` reads cached stats and `/health` is edge-cached. Adding a scan to a DO means adding the allowlist entry in the same PR — the reason is what review checks (`docs/ops.md` §9) |
 
 Two rules that keep the suite honest:
 


### PR DESCRIPTION
## Why

#53 and #54 fixed the two statements behind the 2026-08-18..23 Durable Objects bill (72.38B rows read on 64.57 MB of storage). This PR makes sure the *pattern* — a whole-table scan running per request or per item — cannot come back without being noticed, at three levels: a mechanical test, the review rule Codex applies, and the runbook an operator reads when the counter climbs.

## What changed

**Mechanical guard — `apps/api/test/sqlQueryPlans.test.ts`**
- Extracts every static `SELECT`/`DELETE`/`UPDATE` literal from `src/durable-objects/*.ts` (via Vite `?raw`; `raw-modules.d.ts` types it for the test project only).
- Runs `EXPLAIN QUERY PLAN` on each, on the real schema inside the matching DO (`runInDurableObject`), with dummy bindings.
- Fails on any `SCAN <table>` without `USING INDEX` unless the statement is in `ALLOWED_SCANS` **with a reason** — and fails the other way too when an allowlist entry no longer matches any statement, so the list cannot rot.
- Verified to bite: removing the `SELECT payload FROM rainfall` entry turns `ObservationCacheDO` red with the offending plan in the message.
- All 57 current literals are classified; every allowed scan is either on the 5-minute refresh / alarm path or on a table of a few dozen rows.

**Review rule — `AGENTS.md`**
- New P1 in `## Code Review Rules` (the section Codex consumes) and mirrored in the human-facing severity policy: a DO SQL statement that scans on a per-request or per-item path is blocking; the allowlist reason is what review checks.

**Runbook — `docs/ops.md`**
- §2 gets a symptom row ("rows read climbing by billions a day while storage stays in the tens of MB").
- New §9: where the live counter is (the billing page lags a day), how to find the statement with `sqlite3` + `EXPLAIN QUERY PLAN`, how to decide whether a scan is acceptable (cadence, not table size), the included-per-cycle numbers, and the post-#54 steady state (≈ 80M rows read/day) as the baseline a regression is measured against. Also notes the one thing the repo cannot enforce: the dashboard budget alert.

**`docs/testing.md`** — the three guard tests and the rule that a PR adding a scan adds its allowlist entry in the same diff.

## Verification

- `npx tsc --noEmit` and `npx tsc -p test/tsconfig.json --noEmit` in `apps/api`
- `npm run test -w apps/api` — 43 files, 400 tests passing

No runtime code changes; no UI change (`no-screenshot`).
