### PR TITLE
fix(api): force ForecastNwpDO to restart with the TMD_NWP_TOKEN secret

### DIFF
--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -69,7 +69,19 @@
     // **ไม่ได้** ไปใช้ ForecastPointerDO ซ้ำ ทั้งที่ชื่อชวนให้เข้าใจผิด: ตัวนั้นคือ
     // ตัวชี้ run ของ exposure (E10.3) การเปลี่ยนชื่อ/นำมาใช้ซ้ำต้องลบคลาสก่อน
     // ซึ่งจะทำลายข้อมูลที่เก็บอยู่
-    { "tag": "v8", "new_sqlite_classes": ["ForecastNwpDO"] }
+    { "tag": "v8", "new_sqlite_classes": ["ForecastNwpDO"] },
+    // v9/v10 (2026-08-24): บังคับให้ instance "tmd" สร้างใหม่ ไม่ใช่เพิ่มความสามารถ
+    // ใด ๆ — secret TMD_NWP_TOKEN ถูกตั้งช้ากว่า deploy แรกของ v8 ไป 436 มิลลิวินาที
+    // (`wrangler secret put` ที่ 17:20:22.568Z, deploy โค้ดที่ 17:20:08.260Z) DO
+    // instance ที่เกิดไปก่อนหน้านั้นจึงผูกกับ env ที่ยังไม่มี secret และ **ไม่ยอม
+    // เปลี่ยนแม้ deploy โค้ดใหม่ซ้ำหลายรอบ** เพราะ cron ปลุกมันทุกนาที (ensureFresh)
+    // จึงไม่เคยว่างพอให้ Cloudflare evict ออกจากหน่วยความจำ — ยืนยันจริงด้วย
+    // `lastAttemptAt` ที่ค้างเวลาเดิมข้าม deploy ปกติไปหลายรอบ ก่อนบังคับลบ+สร้างใหม่
+    // ที่นี่ ตามแพตเทิร์นเดียวกับ v6/v7 ของ AlertEngineDO ข้างบน — ข้อมูลที่หายไปคือ
+    // แคชพยากรณ์ล่าสุดของแต่ละจังหวัดเท่านั้น (`latest` table) ไม่มีตารางประวัติ
+    // ให้เสีย และจะเติมกลับเองเต็มภายในรอบ refresh ถัดไป
+    { "tag": "v9", "deleted_classes": ["ForecastNwpDO"] },
+    { "tag": "v10", "new_sqlite_classes": ["ForecastNwpDO"] }
   ],
 
   "triggers": { "crons": ["* * * * *"] },


### PR DESCRIPTION
## What this does

`tmd-nwp` has reported "TMD NWP token not configured" on prod continuously
since PR #58 merged yesterday, even after I redeployed `siahra-api` by hand
today. Diagnosed on prod, not guessed: `lastAttemptAt` in `/api/v1/health`
stayed frozen across that redeploy and through several subsequent cron
ticks, proving the same Durable Object instance kept running rather than
picking up new code.

## Root cause

A race at the very first deploy of `ForecastNwpDO`. The secret was set
436ms after the code that first created the instance:

```
17:20:08.260Z  siahra-api deployed with ForecastNwpDO (PR #58)
17:20:22.132Z  the instance named "tmd" is constructed and makes its first
               attempt — env.TMD_NWP_TOKEN does not exist yet
17:20:22.568Z  `wrangler secret put TMD_NWP_TOKEN` completes
```

A plain `wrangler deploy` does not force an already-running Durable Object to
reconstruct — it keeps the closure over `env` it was built with until
Cloudflare evicts it from memory. This DO's own cron-driven `ensureFresh()`
call happens every minute, which appears to have kept it resident long
enough that natural eviction never happened across ~9.5 hours of otherwise-
idle time.

## The fix

`v9`/`v10` force it: delete the class, then recreate it — exactly the
pattern already used for `AlertEngineDO` (`v6`/`v7`) when the same problem
needed the same fix. The data lost is the `latest` table only — one cached
forecast row per province, no history table exists to lose, and it
repopulates in full on the next successful refresh round.

## Verification

- `wrangler deploy --dry-run` parses the new migration pair cleanly with the
  `FORECAST_NWP` binding intact
- api/web/etl test suites pass in isolation: 425/180/78
- A handful of unrelated tests intermittently hit their 5-second timeout
  only when run together under this machine's current ~10 load average, and
  pass cleanly alone or in any smaller combination — a pre-existing
  environmental condition, not a regression from this one-line config
  change

No screenshot: config-only, no UI.
