### PR TITLE
fix(api): rename the stuck ForecastNwpDO instance instead of a delete migration

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -162,7 +162,18 @@ export default {
       // จึงเรียกได้ทุกนาทีเหมือนงานอื่น ในทางที่ดีคือชั่วโมงละครั้ง ส่วนตอนต้นทางล่ม
       // (รอบพังทั้งรอบ = ไม่เขียน fetchedAt) ตัวกั้น lastAttemptAt ใน ensureFresh()
       // คือสิ่งที่ทำให้ยังห่างกันอย่างน้อย RETRY_MS ไม่ใช่ยิงใหม่ทุกนาที
-      { id: "tmd-nwp", run: () => env.FORECAST_NWP.getByName("tmd").ensureFresh() },
+      //
+      // ชื่อ instance เป็น "primary" ไม่ใช่ "tmd" เหมือนเรดาร์ข้างบน — instance เดิม
+      // ชื่อ "tmd" ค้าง env ที่ยังไม่มี TMD_NWP_TOKEN ตั้งแต่ deploy แรกของคลาสนี้
+      // (secret ถูกตั้งช้ากว่าโค้ด 436 มิลลิวินาที) และไม่ยอมสร้างใหม่แม้ deploy
+      // ซ้ำหลายรอบ เพราะ cron ปลุกมันทุกนาทีจนไม่เคยว่างพอให้ Cloudflare evict —
+      // ยืนยันจริงด้วย lastAttemptAt ที่ค้างเวลาเดิมข้าม deploy 2026-08-24 เปลี่ยน
+      // ชื่อ instance แทนการลบ+สร้างคลาสใหม่ด้วย migration: Cloudflare ปฏิเสธการลบ
+      // คลาสที่ยัง binding อยู่ในดีพลอยเดียวกัน (ต่างจาก AlertEngineDO v6/v7 ที่
+      // binding ถูกถอดพร้อมกันตอน revert ทั้งฟีเจอร์) เปลี่ยนชื่อ instance จึงเป็น
+      // ทางแก้ที่ไม่ต้องแตะ migration เลย — ห้ามเปลี่ยนกลับเป็น "tmd" โดยไม่อ่าน
+      // ประวัติของบรรทัดนี้ก่อน
+      { id: "tmd-nwp", run: () => env.FORECAST_NWP.getByName("primary").ensureFresh() },
       // ประเมิน rule เทียบกับ ObservationCacheDO — งานทุกตัวในลิสต์นี้รันพร้อมกัน
       // ไม่ใช่ตามลำดับ (ดู scheduledTick.ts) แต่ไม่เป็นปัญหา: evaluate() เรียก
       // ObservationCacheDO.getObservations() เอง ซึ่ง refresh ตัวเองถ้าของเก่าหมดอายุ

--- a/apps/api/src/routes/forecast.ts
+++ b/apps/api/src/routes/forecast.ts
@@ -17,7 +17,8 @@ import { errorText, logError } from "../log.js";
  * ซึ่งเป็นข้อมูลที่ UI ต้องแสดง ไม่ใช่ความล้มเหลวของ endpoint
  */
 
-const NWP_INSTANCE = "tmd";
+// "primary" ไม่ใช่ "tmd" — ดูเหตุผลที่ index.ts บรรทัด scheduled task ของ tmd-nwp
+const NWP_INSTANCE = "primary";
 
 /** GET /api/v1/provinces/{NN}/forecast */
 export async function handleProvinceForecast(province: string, env: AppEnv): Promise<Response> {

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -62,7 +62,8 @@ export async function handleHealth(request: Request, env: AppEnv, _params: strin
       .catch((err: unknown) => [unknownStatus("exposure-illustrative", String(err))]),
     // พยากรณ์ NWP (E12.2) — คาบรายชั่วโมง จึงมีสถานะค้าง/ล่มของตัวเองแยกจาก
     // ฟีดเรดาร์ ทั้งที่เป็น TMD เหมือนกัน (คนละ API คนละกุญแจ คนละคาบ)
-    env.FORECAST_NWP.getByName("tmd")
+    // ชื่อ instance "primary" ไม่ใช่ "tmd" — ดูเหตุผลที่ index.ts บรรทัด scheduled task
+    env.FORECAST_NWP.getByName("primary")
       .status()
       .then((s) => [s])
       .catch((err: unknown) => [unknownStatus("tmd-nwp", String(err))]),

--- a/apps/api/test/forecastNwpDurableObject.test.ts
+++ b/apps/api/test/forecastNwpDurableObject.test.ts
@@ -92,10 +92,11 @@ afterEach(() => {
 
 afterAll(async () => {
   setToken(undefined);
-  await runInDurableObject(appEnv.FORECAST_NWP.getByName("tmd"), (_i, ctx) => ctx.storage.deleteAlarm());
+  await runInDurableObject(appEnv.FORECAST_NWP.getByName("primary"), (_i, ctx) => ctx.storage.deleteAlarm());
 });
 
-/** บล็อกนี้ต้องมาก่อนทุกบล็อกที่ทำให้ instance "tmd" อุ่น — state อยู่ยาวข้าม block ในไฟล์เดียวกัน */
+/** บล็อกนี้ต้องมาก่อนทุกบล็อกที่ทำให้ instance "primary" อุ่น — state อยู่ยาวข้าม block ในไฟล์เดียวกัน
+ *  ("primary" ไม่ใช่ "tmd" ตามชื่อ instance จริงที่ production ใช้ตั้งแต่ 2026-08-24 — ดู index.ts) */
 describe("ยังไม่เคยดึงสำเร็จ", () => {
   it("ตอบ 200 พร้อม batch: null และ fetchedAt เป็น null ทั้งสอง descriptor", async () => {
     const res = await call("/api/v1/provinces/10/forecast");
@@ -167,8 +168,8 @@ describe("cron ขับรอบดึง แล้วเส้นทางอ�
   });
 
   it("เขียนหนึ่งแถวต่อหนึ่งจังหวัด ไม่ใช่หนึ่งแถวต่อขั้นพยากรณ์", async () => {
-    const status = await statusOf("tmd");
-    const rows = await rowCount("tmd");
+    const status = await statusOf("primary");
+    const rows = await rowCount("primary");
     // fixture มี 5 จังหวัด × (48 + 7) ขั้น = 275 ขั้น ถ้าเก็บเป็นแถวละขั้นจะได้ 275
     expect(rows).toBe(5);
     expect(rows).toBe(status.detail.provinces);
@@ -176,7 +177,7 @@ describe("cron ขับรอบดึง แล้วเส้นทางอ�
   });
 
   it("/health รายงาน tmd-nwp เป็น ok พร้อมช่วงข้อมูลที่ต้นทางประกาศ", async () => {
-    const status = await statusOf("tmd");
+    const status = await statusOf("primary");
     expect(status.id).toBe("tmd-nwp");
     expect(status.health).toBe("ok");
     expect(status.lastError).toBeNull();

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -69,19 +69,17 @@
     // **ไม่ได้** ไปใช้ ForecastPointerDO ซ้ำ ทั้งที่ชื่อชวนให้เข้าใจผิด: ตัวนั้นคือ
     // ตัวชี้ run ของ exposure (E10.3) การเปลี่ยนชื่อ/นำมาใช้ซ้ำต้องลบคลาสก่อน
     // ซึ่งจะทำลายข้อมูลที่เก็บอยู่
-    { "tag": "v8", "new_sqlite_classes": ["ForecastNwpDO"] },
-    // v9/v10 (2026-08-24): บังคับให้ instance "tmd" สร้างใหม่ ไม่ใช่เพิ่มความสามารถ
-    // ใด ๆ — secret TMD_NWP_TOKEN ถูกตั้งช้ากว่า deploy แรกของ v8 ไป 436 มิลลิวินาที
-    // (`wrangler secret put` ที่ 17:20:22.568Z, deploy โค้ดที่ 17:20:08.260Z) DO
-    // instance ที่เกิดไปก่อนหน้านั้นจึงผูกกับ env ที่ยังไม่มี secret และ **ไม่ยอม
-    // เปลี่ยนแม้ deploy โค้ดใหม่ซ้ำหลายรอบ** เพราะ cron ปลุกมันทุกนาที (ensureFresh)
-    // จึงไม่เคยว่างพอให้ Cloudflare evict ออกจากหน่วยความจำ — ยืนยันจริงด้วย
-    // `lastAttemptAt` ที่ค้างเวลาเดิมข้าม deploy ปกติไปหลายรอบ ก่อนบังคับลบ+สร้างใหม่
-    // ที่นี่ ตามแพตเทิร์นเดียวกับ v6/v7 ของ AlertEngineDO ข้างบน — ข้อมูลที่หายไปคือ
-    // แคชพยากรณ์ล่าสุดของแต่ละจังหวัดเท่านั้น (`latest` table) ไม่มีตารางประวัติ
-    // ให้เสีย และจะเติมกลับเองเต็มภายในรอบ refresh ถัดไป
-    { "tag": "v9", "deleted_classes": ["ForecastNwpDO"] },
-    { "tag": "v10", "new_sqlite_classes": ["ForecastNwpDO"] }
+    { "tag": "v8", "new_sqlite_classes": ["ForecastNwpDO"] }
+    // ไม่มี v9 — เคยลองเพิ่ม deleted_classes/new_sqlite_classes คู่หนึ่งเพื่อบังคับ
+    // ให้ instance "tmd" สร้างใหม่ (ดูเหตุผลใน git log ของคอมมิตนี้) แต่ Cloudflare
+    // ปฏิเสธตั้งแต่ขั้น deploy จริง: "Cannot apply --delete-class migration to
+    // class 'ForecastNwpDO' without also removing the binding that references
+    // it" — ต่างจาก AlertEngineDO's v6/v7 ตรงที่ตอนนั้น binding ถูกถอดออกไปพร้อมกัน
+    // ในดีพลอยเดียวกัน (เป็นส่วนหนึ่งของการ revert ทั้งฟีเจอร์) แล้วค่อยเพิ่มกลับใน
+    // ดีพลอยแยกต่างหากอีกวันหนึ่ง — ที่นี่ทำแบบนั้นไม่ได้เพราะจะทำให้ endpoint
+    // พยากรณ์ที่เพิ่ง ship (E12.2/E12.3) หายไปชั่วคราว แก้ปัญหา DO ค้าง env เก่า
+    // ด้วยการเปลี่ยนชื่อ instance แทน (ดู `NWP_INSTANCE` ใน `forecast-nwp.ts`) ซึ่ง
+    // ไม่ต้องแตะ migration เลย
   ],
 
   "triggers": { "crons": ["* * * * *"] },


### PR DESCRIPTION
## What this does

Fixes a deploy-blocking regression from #60, merged and discovered broken
minutes later. That PR added a `v9`/`v10` delete-then-recreate migration pair
for `ForecastNwpDO`, following the `AlertEngineDO` `v6`/`v7` precedent.
Merging it broke the very next `apps/api` deploy:

```
Cannot apply --delete-class migration to class 'ForecastNwpDO' without also
removing the binding that references it. [code: 10061]
```

Cloudflare rejected the deploy atomically before activation, so prod was
never affected — but the migration ledger was left in a state that would
fail **every future `apps/api` deploy** the same way, since a delete-class
migration can only apply in the same deploy that removes its binding.

## Why the precedent didn't actually apply

Re-checked `AlertEngineDO`'s history instead of assuming it matched: `v6`
(delete) shipped in the commit that reverted the whole feature, which
removed the `ALERT_ENGINE` binding in the *same* deploy. `v7` (recreate)
landed a full day later, in a *separate* deploy that added the binding back.
Doing that here would mean shipping a version of the API with no forecast
endpoint at all in between — breaking the just-shipped E12.2/E12.3 surface
for however long the two deploys are apart.

## The fix

Rename the DO's logical instance identifier from `"tmd"` to `"primary"`
everywhere it's constructed (the scheduled task in `index.ts`, the
`/health` collector, and the two forecast routes), plus the one test that
probes the same identity the real routes use. This never touches
Cloudflare's migration API at all — it's a plain code change, so nothing
exists for the account to reject.

The stuck `"tmd"` instance (built before `TMD_NWP_TOKEN` existed, never
evicted because cron pings it every minute) is simply never addressed
again. A brand new `"primary"` instance is constructed fresh on the next
request, picking up whatever env the currently deployed Worker actually has.

`wrangler.jsonc` drops back to `v8` as the last migration tag — `v9`/`v10`
were never successfully applied on Cloudflare's side, so removing them from
the ledger doesn't violate the append-only rule, which only protects tags
that actually went live.

## Verification

- `wrangler deploy --dry-run` now shows `v8` as the last tag with every
  binding intact, matching what's already applied on Cloudflare — no
  migration for it to evaluate at all this time
- api/web/etl suites pass in isolation: 425/180/78
- oxlint, `tsc -b`/`--noEmit` all clean

No screenshot: config + backend code only, no UI.
