### PR TITLE
feat(web): add forecast time strip alongside the history timeline (E12.4a)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { BottomBar } from "./components/layout/BottomBar";
+import { ForecastStrip } from "./components/layout/ForecastStrip";
 import type { MapApi, MapInfo, MapLayers } from "./components/layout/Map3DCanvas";
 import { MapViewport } from "./components/layout/MapViewport";
 import { ExaggerationControl } from "./components/layout/ExaggerationControl";
@@ -101,6 +102,9 @@ export default function App() {
   });
   /** null = live; otherwise an ISO time the map is scrubbed back to. */
   const [atIso, setAtIso] = useState<string | null>(INITIAL.atIso);
+  // E12.4a — ขั้นพยากรณ์ TMD ที่กำลังเลือกอยู่ใน ForecastStrip; null = ยังไม่ได้
+  // เลือก ไม่รีเซ็ตตอนเปลี่ยนจังหวัด เหมือนกับ atIso ข้างบน (ธรรมเนียมเดียวกัน)
+  const [forecastAtIso, setForecastAtIso] = useState<string | null>(INITIAL.forecastAtIso);
   const [exaggeration, setExaggeration] = useState(INITIAL.exaggeration ?? 1);
   const [pose, setPose] = useState<CameraPose | null>(INITIAL.pose);
   const [mapInfo, setMapInfo] = useState<MapInfo | null>(null);
@@ -216,6 +220,19 @@ export default function App() {
     setLayers((l) => ({ ...l, [key]: value }));
   }, []);
 
+  // E12.4a — atIso (ย้อนหลัง) กับ forecastAtIso (พยากรณ์ล่วงหน้า) แยกกันคนละ
+  // useState แต่ต้องกันไม่ให้ทั้งคู่ non-null พร้อมกัน: เลือกฝั่งไหน อีกฝั่งกลับ
+  // เป็น null ทันที — ตรงกับกฎเดียวกับที่ permalink.ts ใช้ตัดสินว่า `t` หรือ `f`
+  // ชนะเมื่อทั้งคู่ถูกส่งมาพร้อมกัน (`t`/observed ชนะเสมอ)
+  const handleAtIsoChange = useCallback((iso: string | null) => {
+    setAtIso(iso);
+    if (iso !== null) setForecastAtIso(null);
+  }, []);
+  const handleForecastAtIsoChange = useCallback((iso: string | null) => {
+    setForecastAtIso(iso);
+    if (iso !== null) setAtIso(null);
+  }, []);
+
   // `lang` ต้องอยู่ในสถานะที่ sync ลง URL ด้วย ไม่งั้นการเปิดลิงก์ `?lang=en`
   // แล้วปล่อยไว้ 400 มิลลิวินาที จะถูก replaceState เขียนทับจนพารามิเตอร์หายไป
   usePermalinkSync({
@@ -227,6 +244,7 @@ export default function App() {
     // ออกจากลิงก์ตอนที่ผู้ใช้เปิดมัน เพราะทุกชั้นกลายเป็นเปิดหมดพอดี
     defaultLayers: DEFAULT_LAYERS_RECORD,
     atIso,
+    forecastAtIso,
     lang,
   });
 
@@ -411,7 +429,12 @@ export default function App() {
                 <ExaggerationControl value={exaggeration} onChange={setExaggeration} />
               </div>
             </div>
-            <TimelineBar atIso={atIso} onChange={setAtIso} />
+            {/* TimelineBar (observed) และ ForecastStrip (TMD) ต้องอยู่แถวเดียวกัน
+                เพื่อให้ปลาย "ปัจจุบัน" ของอันแรกชนกับปลาย "0h" ของอันหลัง */}
+            <div className="flex flex-col gap-2">
+              <TimelineBar atIso={atIso} onChange={handleAtIsoChange} />
+              <ForecastStrip state={forecast} forecastAtIso={forecastAtIso} onChange={handleForecastAtIsoChange} />
+            </div>
           </div>
           <MobileSheet
             open={sheetOpen}
@@ -559,7 +582,10 @@ export default function App() {
             exaggeration={exaggeration}
             onExaggerationChange={setExaggeration}
             atIso={atIso}
-            onAtIsoChange={setAtIso}
+            onAtIsoChange={handleAtIsoChange}
+            forecast={forecast}
+            forecastAtIso={forecastAtIso}
+            onForecastAtIsoChange={handleForecastAtIsoChange}
             left={safeArea.left}
             right={safeArea.right}
             bottom={GUTTER}

--- a/apps/web/src/components/layout/BottomBar.tsx
+++ b/apps/web/src/components/layout/BottomBar.tsx
@@ -1,7 +1,9 @@
 import { useLayoutEffect, useRef } from "react";
 import type { ObservationSummary } from "@siahra/shared-types";
 import type { ApiHealthState } from "../../hooks/useApiHealth";
+import type { ProvinceForecastState } from "../../hooks/useProvinceForecast";
 import { ExaggerationControl } from "./ExaggerationControl";
+import { ForecastStrip } from "./ForecastStrip";
 import type { MapInfo } from "./Map3DCanvas";
 import { MapAttribution } from "./MapAttribution";
 import { SourceStatusBar } from "./SourceStatusBar";
@@ -22,6 +24,9 @@ export function BottomBar({
   onExaggerationChange,
   atIso,
   onAtIsoChange,
+  forecast,
+  forecastAtIso,
+  onForecastAtIsoChange,
   left,
   right,
   bottom,
@@ -35,6 +40,9 @@ export function BottomBar({
   onExaggerationChange: (f: number) => void;
   atIso: string | null;
   onAtIsoChange: (atIso: string | null) => void;
+  forecast: ProvinceForecastState;
+  forecastAtIso: string | null;
+  onForecastAtIsoChange: (forecastAtIso: string | null) => void;
   left: number;
   right: number;
   bottom: number;
@@ -74,8 +82,16 @@ export function BottomBar({
           <ExaggerationControl value={exaggeration} onChange={onExaggerationChange} />
         </div>
       </div>
-      <div className="pointer-events-auto">
-        <TimelineBar atIso={atIso} onChange={onAtIsoChange} />
+      {/* TimelineBar (observed, scrubs back) and ForecastStrip (TMD, scrubs
+          forward) share one row so TimelineBar's live/"now" end and
+          ForecastStrip's 0h end sit right next to each other. */}
+      <div className="pointer-events-auto flex flex-col gap-2 @2xl:flex-row @2xl:items-stretch">
+        <div className="min-w-0 @2xl:flex-1">
+          <TimelineBar atIso={atIso} onChange={onAtIsoChange} />
+        </div>
+        <div className="min-w-0 @2xl:flex-1">
+          <ForecastStrip state={forecast} forecastAtIso={forecastAtIso} onChange={onForecastAtIsoChange} />
+        </div>
       </div>
       <div className="pointer-events-auto">
         <StatStrip summary={summary} loading={loading} />

--- a/apps/web/src/components/layout/ForecastStrip.tsx
+++ b/apps/web/src/components/layout/ForecastStrip.tsx
@@ -1,0 +1,224 @@
+import { X } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import type { ForecastStep } from "@siahra/shared-types";
+import type { ProvinceForecastState } from "../../hooks/useProvinceForecast";
+import { EPISTEMIC_BADGE } from "../../lib/layerFreshness";
+import { resolveError } from "../../lib/errorMessage";
+import { formatDateTime } from "../../lib/time";
+import { formatNumber } from "../../lib/number";
+import { useLang } from "../../i18n/context";
+import { useNow } from "../../hooks/useNow";
+
+/** ค่าคงที่ตัวเดียว — กัน `batch?.hourly ?? []` สร้าง array ใหม่ทุกเรนเดอร์
+ *  จนทำให้ `useMemo(..., [steps])` ด้านล่าง invalidate ทุกครั้งโดยไม่จำเป็น */
+const EMPTY_STEPS: ForecastStep[] = [];
+
+/**
+ * เหมือน `isStale` ใน `ForecastCard.tsx` เป๊ะ — คัดลอกสั้น ๆ แทนการ export
+ * (เหตุผลเดียวกับที่การ์ดนั้นเขียนไว้: ไม่คุ้มที่จะแก้ไฟล์นั้นเพื่อ export
+ * ฟังก์ชันสี่บรรทัดออกมาใช้อีกที่หนึ่ง)
+ */
+function isStale(fetchedAt: string | null, staleAfterSeconds: number | undefined, nowMs: number): boolean {
+  if (!fetchedAt) return true;
+  if (!staleAfterSeconds) return false;
+  const ms = Date.parse(fetchedAt);
+  if (Number.isNaN(ms)) return false;
+  return nowMs - ms > staleAfterSeconds * 1000;
+}
+
+/**
+ * แถบเลื่อนดูพยากรณ์รายชั่วโมงของ TMD (E12.4a) — คู่กับ `TimelineBar.tsx` แต่
+ * เลื่อน "ไปข้างหน้า" ผ่านขั้นพยากรณ์ ไม่ใช่ย้อนหลังผ่านค่าตรวจวัดจริง
+ *
+ * งานนี้คือ state + UI เท่านั้น: การเลือกขั้นที่นี่ไม่มีผลต่อแผนที่ 3 มิติเลย
+ * (นั่นเป็นงานแยกต่างหากที่ยังไม่ได้ตัดสินใจเรื่องการออกแบบ) จึงไม่มี prop ไหน
+ * เชื่อมไปยัง scene/**
+ *
+ * ภาษาภาพ: ใช้โทเคนสีเดียวกับ `EPISTEMIC_BADGE.forecast` (`--color-accent` /
+ * `#9dc0ff`) เพราะเป็นสีที่ผูกกับ "ชั้นพยากรณ์" อยู่แล้วทั้งระบบ — สิ่งที่ทำให้
+ * แถบนี้ไม่ถูกอ่านว่าเป็นส่วนต่อของ `TimelineBar` (ซึ่งพื้นทึบเหมือนกัน) คือ
+ * "ลาย" ไม่ใช่ "สี": รางเป็นลายเส้นทแยงกับกรอบเส้นประตลอดทั้งแถบ (ดู index.css
+ * `.range-slider-forecast`) ตามภาษาเดียวกับที่ `lib/illustrativeStyle.ts` ใช้
+ * แยกชั้น "คำนวณ/แบบจำลอง" ออกจากชั้น "ตรวจวัดจริง" ด้วยลายเส้นแทนสี
+ *
+ * ไม่มีการไล่สีตามระดับปริมาณฝนเลย (ต่างจาก sparkline ของระดับน้ำ) — ไม่มีเกณฑ์
+ * ที่ต้นทางรับรองสำหรับฝนรายชั่วโมง มีแต่เกณฑ์ 24 ชม.ที่อ้างอิง TMD ได้ (ดู
+ * `apps/api/src/exposure/compute.ts` บรรทัด ~68-84) ตัวเลขที่นี่จึงแสดงดิบ ๆ
+ */
+export function ForecastStrip({
+  state,
+  forecastAtIso,
+  onChange,
+}: {
+  state: ProvinceForecastState;
+  /** ขั้นที่กำลังเลือกอยู่ (ตรงกับ `validAt` ของขั้นใดขั้นหนึ่ง) หรือ null = ยังไม่เลือก */
+  forecastAtIso: string | null;
+  onChange: (forecastAtIso: string | null) => void;
+}) {
+  const { lang, t } = useLang();
+  const nowMs = useNow();
+  const { data, loading, error } = state;
+  const batch = data?.batch ?? null;
+  const steps = batch?.hourly ?? EMPTY_STEPS;
+  const n = steps.length;
+  const hourlyDescriptor = data?.layers.hourly ?? null;
+  const stale = hourlyDescriptor
+    ? isStale(hourlyDescriptor.fetchedAt, hourlyDescriptor.staleAfterSeconds, nowMs)
+    : false;
+  const badge = EPISTEMIC_BADGE.forecast;
+
+  const selectedIndex = useMemo(() => {
+    if (!forecastAtIso) return -1;
+    return steps.findIndex((s) => s.validAt === forecastAtIso);
+  }, [forecastAtIso, steps]);
+  const selected = selectedIndex >= 0 ? steps[selectedIndex] : null;
+
+  // ขั้นเดียว (n===1): min===max บน <input type="range"> ทำให้ลากหรือกดลูกศร
+  // ไม่ยิง onChange เลย — ขั้นนั้นเลยกลายเป็นเลือกไม่ได้ทั้งที่มีข้อมูลจริงอยู่
+  // เลือกให้อัตโนมัติแทนการรอผู้ใช้ลากตัวควบคุมที่ลากไม่ได้จริง ๆ
+  useEffect(() => {
+    if (n === 1 && forecastAtIso !== steps[0].validAt) onChange(steps[0].validAt);
+  }, [n, steps, forecastAtIso, onChange]);
+
+  // จุดกำกับบนราง: ไม่เกิน 5 จุด กระจายตามจำนวนขั้นจริง (ต้นทางอาจส่งมาสั้นกว่า
+  // 48 ชม. เสมอ ห้าม hard-code จำนวนขั้น) — ป้ายเป็นชั่วโมงที่ห่างจากขั้นแรก
+  // ไม่ใช่ "ตอนนี้" เพราะขั้นแรกที่ TMD ส่งมาอาจไม่ตรงกับเวลาปัจจุบันเป๊ะ
+  const tickIdxs = useMemo(() => {
+    if (n === 0) return [];
+    const count = Math.min(5, n);
+    const idxs = new Set<number>();
+    for (let i = 0; i < count; i++) idxs.add(Math.round((i * (n - 1)) / Math.max(1, count - 1)));
+    return [...idxs].sort((a, b) => a - b);
+  }, [n]);
+
+  // ไม่มีขั้นให้เลื่อนเลย: แสดงเป็นสถานะปิด/หรี่ที่มองเห็นได้ ไม่ใช่ตัวควบคุมที่
+  // กดได้แต่ไม่มีอะไรให้เลื่อน — แยกข้อความตามข้อเท็จจริงที่ต่างกันสามแบบ (ลอก
+  // ตรรกะเดียวกับ ForecastCard.tsx): คำขอของเราเองล้มเหลว / กำลังโหลด / backend
+  // ตอบสำเร็จแต่ไม่เคยดึงจาก TMD สำเร็จเลย / TMD ส่งขั้นรายชั่วโมงมาว่างเปล่า
+  if (n === 0) {
+    const message =
+      error && !data
+        ? resolveError(t, error)
+        : loading && !data
+          ? t("common.loading")
+          : data && !batch
+            ? t("forecast.none")
+            : t("forecast.strip.noSteps");
+    return (
+      <div className="glass flex items-center gap-3 rounded-2xl py-2 pr-4 pl-2.5 opacity-50">
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none ring-1 ring-inset ${badge.className}`}
+          title={t(badge.titleKey)}
+        >
+          {t(badge.labelKey)}
+        </span>
+        <p className="min-w-0 flex-1 truncate text-xs text-[var(--color-fg-subtle)]">{message}</p>
+      </div>
+    );
+  }
+
+  const progress = selected ? (selectedIndex / Math.max(1, n - 1)) * 100 : 0;
+
+  return (
+    <div className={`glass flex items-center gap-3 rounded-2xl py-2 pr-4 pl-2.5 ${stale ? "opacity-60" : ""}`}>
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        disabled={!selected}
+        className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-full text-[var(--color-fg-muted)] transition-colors hover:bg-white/8 hover:text-white disabled:cursor-default disabled:opacity-35 disabled:hover:bg-transparent"
+        aria-label={t("forecast.strip.clear")}
+        title={t("forecast.strip.clear")}
+      >
+        <X size={15} />
+      </button>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <span
+              className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none ring-1 ring-inset ${badge.className}`}
+              title={t(badge.titleKey)}
+            >
+              {t(badge.labelKey)}
+            </span>
+            <span className="hidden truncate text-[11px] text-[var(--color-fg-subtle)] @2xl:inline">
+              {t("forecast.headerCount", { n })}
+            </span>
+            {error ? (
+              <span className="shrink-0 truncate text-[10px] text-[var(--color-danger)]">
+                {resolveError(t, error)}
+              </span>
+            ) : stale ? (
+              <span className="shrink-0 rounded-md bg-[var(--color-risk-medium)]/15 px-1.5 py-0.5 text-[10px] leading-none whitespace-nowrap text-[var(--color-risk-medium)]">
+                {t("forecast.staleNote")}
+              </span>
+            ) : null}
+          </div>
+          <span className="ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums text-[#9dc0ff]">
+            {selected ? formatDateTime(lang, selected.validAt) : t("forecast.strip.notSelected")}
+          </span>
+        </div>
+
+        <input
+          type="range"
+          min={0}
+          max={n - 1}
+          step={1}
+          value={selected ? selectedIndex : 0}
+          onChange={(e) => onChange(steps[Number(e.target.value)].validAt)}
+          aria-label={t("forecast.strip.slider")}
+          aria-valuetext={selected ? formatDateTime(lang, selected.validAt) : t("forecast.strip.notSelected")}
+          className="range-slider-forecast mt-2 w-full"
+          style={{ "--range-progress": `${progress}%` } as React.CSSProperties}
+        />
+
+        {/* จุดกำกับวางตามตำแหน่งจริงบนราง เหมือน TimelineBar ไม่ใช่กระจายเท่า ๆ กัน */}
+        <div className="relative mt-0.5 h-3.5 text-[10px] leading-none text-[var(--color-fg-subtle)]">
+          {tickIdxs.map((idx, i) => {
+            const pct = n <= 1 ? 0 : (idx / (n - 1)) * 100;
+            const hoursAhead = Math.round((Date.parse(steps[idx].validAt) - Date.parse(steps[0].validAt)) / 3600000);
+            const last = i === tickIdxs.length - 1;
+            return (
+              <span
+                key={idx}
+                className="absolute top-0 whitespace-nowrap tabular-nums"
+                style={{
+                  left: `${pct}%`,
+                  transform: i === 0 ? "none" : last ? "translateX(-100%)" : "translateX(-50%)",
+                }}
+              >
+                {t("forecast.strip.tickHours", { n: hoursAhead })}
+              </span>
+            );
+          })}
+        </div>
+
+        {/* ค่าดิบของขั้นที่เลือก — ห้ามไล่สีตามแบนด์ปริมาณฝน (ไม่มีเกณฑ์ทางการ
+            สำหรับความละเอียดรายชั่วโมง) และ null ต้องขึ้นข้อความชัดเจนว่า TMD
+            ไม่ได้ส่งค่านี้มา ห้ามเว้นว่างหรือแสดงเป็น 0 เงียบ ๆ */}
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-[var(--color-fg)]">
+          {selected ? (
+            <>
+              <span>
+                <span className="text-[var(--color-fg-subtle)]">{t("forecast.strip.rain")} </span>
+                {selected.rainMm !== null
+                  ? `${formatNumber(lang, selected.rainMm, 1)} ${t("forecast.hourly.unit")}`
+                  : t("forecast.strip.notSent")}
+              </span>
+              <span>
+                <span className="text-[var(--color-fg-subtle)]">{t("forecast.strip.temp")} </span>
+                {selected.tempC !== null ? `${formatNumber(lang, selected.tempC, 1)}°C` : t("forecast.strip.notSent")}
+              </span>
+              <span>
+                <span className="text-[var(--color-fg-subtle)]">{t("forecast.strip.cond")} </span>
+                {selected.cond !== null ? String(selected.cond) : t("forecast.strip.notSent")}
+              </span>
+            </>
+          ) : (
+            <span className="text-[var(--color-fg-subtle)]">{t("forecast.strip.prompt")}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/usePermalink.test.ts
+++ b/apps/web/src/hooks/usePermalink.test.ts
@@ -10,6 +10,7 @@ describe("permalink round-trip", () => {
       layers: { terrain: true, water: true, buildings: false },
       defaultLayers: { terrain: true, water: true, buildings: true },
       atIso: "2026-08-18T09:00:00.000Z",
+      forecastAtIso: null,
       lang: "th",
     });
 
@@ -26,6 +27,7 @@ describe("permalink round-trip", () => {
       exaggeration: 1.6,
       layers: ["terrain", "water"],
       atIso: "2026-08-18T09:00:00.000Z",
+      forecastAtIso: null,
       lang: null,
     });
   });
@@ -38,6 +40,7 @@ describe("permalink round-trip", () => {
       layers: { terrain: true },
       defaultLayers: { terrain: true },
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(search).toBe("?p=50");
@@ -52,6 +55,7 @@ describe("permalink round-trip", () => {
       layers: { terrain: true, water: true },
       defaultLayers: { terrain: true, water: true },
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(search).not.toContain("layers=");
@@ -69,6 +73,7 @@ describe("permalink round-trip", () => {
       layers: { terrain: false, water: false },
       defaultLayers: { terrain: true, water: true },
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(search).toContain("layers=");
@@ -91,6 +96,7 @@ describe("permalink round-trip", () => {
       layers: { lowland: true, exposure: true, buildings: true },
       defaultLayers,
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(on).toContain("layers=");
@@ -105,6 +111,7 @@ describe("permalink round-trip", () => {
       layers: { ...defaultLayers },
       defaultLayers,
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(off).not.toContain("layers=");
@@ -118,6 +125,7 @@ describe("permalink round-trip", () => {
       layers: { lowland: true, exposure: false, buildings: false },
       defaultLayers,
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(parsePermalink(mixed).layers).toEqual(["lowland"]);
@@ -131,6 +139,7 @@ describe("permalink round-trip", () => {
       layers: {},
       defaultLayers: {},
       atIso: null,
+      forecastAtIso: null,
       lang: "th",
     });
     expect(parsePermalink(search).pose).toEqual({
@@ -157,6 +166,75 @@ describe("parsePermalink rejects junk", () => {
     expect(parsePermalink("?t=2026-08-18T09:00:00.000Z").atIso).toBe("2026-08-18T09:00:00.000Z");
   });
 
+  it("drops an unparseable forecast timestamp", () => {
+    expect(parsePermalink("?f=yesterday").forecastAtIso).toBeNull();
+    expect(parsePermalink("?f=2026-08-18T09:00:00.000Z").forecastAtIso).toBe(
+      "2026-08-18T09:00:00.000Z",
+    );
+  });
+
+  /**
+   * E12.4a — `t` (observed history) และ `f` (พยากรณ์ที่กำลังเลื่อนดู) ต้องไม่ถูก
+   * ยอมรับพร้อมกันทั้งคู่ ไม่ว่าจะทาง `serialisePermalink` (เขียนแค่ตัวเดียว)
+   * หรือทาง `parsePermalink` ตอนอ่านลิงก์ที่ถูกแก้มือให้มีทั้งสองคีย์ — `t`
+   * ชนะเสมอเพราะเป็นพารามิเตอร์เดิมที่มีมาก่อน และการย้อนกลับไปที่ค่าตรวจวัดจริง
+   * ปลอดภัยกว่าการค้างอยู่ที่ขั้นพยากรณ์ที่ยังไม่ได้ยืนยัน
+   */
+  it("t wins over f when a hand-edited URL carries both", () => {
+    // ทั้งคู่ parse ได้จริง — t ชนะ, f หายไป
+    expect(
+      parsePermalink("?t=2026-08-18T09:00:00.000Z&f=2026-08-19T00:00:00.000Z"),
+    ).toMatchObject({
+      atIso: "2026-08-18T09:00:00.000Z",
+      forecastAtIso: null,
+    });
+
+    // t มีอยู่แต่ parse ไม่ขึ้น (ขยะ) — ยังชนะอยู่ดี เพราะการมีคีย์ t เท่ากับ
+    // ผู้เขียนลิงก์ตั้งใจอ้างค่าตรวจวัดจริง แม้ค่าจะพังก็ตาม
+    expect(parsePermalink("?t=yesterday&f=2026-08-19T00:00:00.000Z")).toMatchObject({
+      atIso: null,
+      forecastAtIso: null,
+    });
+
+    // ไม่มี t เลย — f ใช้ได้ตามปกติ
+    expect(parsePermalink("?f=2026-08-19T00:00:00.000Z")).toMatchObject({
+      atIso: null,
+      forecastAtIso: "2026-08-19T00:00:00.000Z",
+    });
+  });
+
+  it("serialisePermalink never writes both t and f, even if both are passed non-null", () => {
+    const search = serialisePermalink({
+      provinceCode: "10",
+      pose: null,
+      exaggeration: 1,
+      layers: {},
+      defaultLayers: {},
+      atIso: "2026-08-18T09:00:00.000Z",
+      forecastAtIso: "2026-08-19T00:00:00.000Z",
+      lang: "th",
+    });
+    expect(search).toContain("t=2026-08-18T09%3A00%3A00.000Z");
+    expect(search).not.toContain("f=");
+    expect(parsePermalink(search).forecastAtIso).toBeNull();
+  });
+
+  it("writes f when only forecastAtIso is set", () => {
+    const search = serialisePermalink({
+      provinceCode: "10",
+      pose: null,
+      exaggeration: 1,
+      layers: {},
+      defaultLayers: {},
+      atIso: null,
+      forecastAtIso: "2026-08-19T00:00:00.000Z",
+      lang: "th",
+    });
+    expect(search).toContain("f=2026-08-19T00%3A00%3A00.000Z");
+    expect(search).not.toContain("t=");
+    expect(parsePermalink(search).forecastAtIso).toBe("2026-08-19T00:00:00.000Z");
+  });
+
   it("returns all-null for an empty query", () => {
     expect(parsePermalink("")).toEqual({
       provinceCode: null,
@@ -164,6 +242,7 @@ describe("parsePermalink rejects junk", () => {
       exaggeration: null,
       layers: null,
       atIso: null,
+      forecastAtIso: null,
       lang: null,
     });
   });

--- a/apps/web/src/hooks/usePermalink.ts
+++ b/apps/web/src/hooks/usePermalink.ts
@@ -15,11 +15,21 @@ export function readPermalink(): PermalinkState {
  * timeline position.
  */
 export function usePermalinkSync(state: PermalinkInput) {
-  const { provinceCode, pose, exaggeration, layers, defaultLayers, atIso, lang } = state;
+  const { provinceCode, pose, exaggeration, layers, defaultLayers, atIso, forecastAtIso, lang } = state;
   const timer = useRef<number | null>(null);
   const serialized = useMemo(
-    () => serialisePermalink({ provinceCode, pose, exaggeration, layers, defaultLayers, atIso, lang }),
-    [provinceCode, pose, exaggeration, layers, defaultLayers, atIso, lang],
+    () =>
+      serialisePermalink({
+        provinceCode,
+        pose,
+        exaggeration,
+        layers,
+        defaultLayers,
+        atIso,
+        forecastAtIso,
+        lang,
+      }),
+    [provinceCode, pose, exaggeration, layers, defaultLayers, atIso, forecastAtIso, lang],
   );
 
   useEffect(() => {

--- a/apps/web/src/i18n/en.ts
+++ b/apps/web/src/i18n/en.ts
@@ -369,6 +369,18 @@ export const en: Record<keyof typeof th, string> = {
   "forecast.daily.unit": "mm/24h",
   "forecast.daily.none": "TMD did not send daily rain values in this batch",
 
+  // ── Forecast time strip (E12.4a) ────────────────────────────────────────
+  "forecast.strip.clear": "Clear selection",
+  "forecast.strip.slider": "Scrub hourly figures",
+  "forecast.strip.notSelected": "No hour selected",
+  "forecast.strip.prompt": "Drag to see this hour's figures",
+  "forecast.strip.rain": "Rain",
+  "forecast.strip.temp": "Temp",
+  "forecast.strip.cond": "Cond. code",
+  "forecast.strip.notSent": "TMD did not send this value",
+  "forecast.strip.tickHours": "+{n} h",
+  "forecast.strip.noSteps": "TMD sent no hourly steps in this batch",
+
   // ── Dam card ──────────────────────────────────────────────────────────
   "dam.title": "Dams and reservoirs",
   "dam.count": "{n} sites",

--- a/apps/web/src/i18n/th.ts
+++ b/apps/web/src/i18n/th.ts
@@ -401,6 +401,18 @@ export const th = {
   "forecast.daily.unit": "มม./24 ชม.",
   "forecast.daily.none": "TMD ไม่ได้ส่งค่าปริมาณฝนรายวันมาในชุดนี้",
 
+  // ── แถบเวลาพยากรณ์ (ForecastStrip, E12.4a) ────────────────────────────
+  "forecast.strip.clear": "ล้างการเลือก",
+  "forecast.strip.slider": "เลื่อนดูตัวเลขรายชั่วโมง",
+  "forecast.strip.notSelected": "ยังไม่ได้เลือกชั่วโมง",
+  "forecast.strip.prompt": "ลากเพื่อดูตัวเลขของชั่วโมงนั้น",
+  "forecast.strip.rain": "ฝน",
+  "forecast.strip.temp": "อุณหภูมิ",
+  "forecast.strip.cond": "รหัสสภาพอากาศ",
+  "forecast.strip.notSent": "TMD ไม่ได้ส่งค่านี้มา",
+  "forecast.strip.tickHours": "+{n} ชม.",
+  "forecast.strip.noSteps": "TMD ไม่ได้ส่งขั้นรายชั่วโมงมาในชุดนี้เลย",
+
   // ── การ์ดเขื่อน ───────────────────────────────────────────────────────
   "dam.title": "เขื่อนและอ่างเก็บน้ำ",
   "dam.count": "{n} แห่ง",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -238,3 +238,99 @@ body {
   border: 2px solid var(--color-accent);
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
 }
+
+/*
+ * Forecast strip scrubber (E12.4a): same accent token as `EPISTEMIC_BADGE.forecast`
+ * (lib/layerFreshness.ts) — the distinction from `.range-slider` above is
+ * texture, not hue, matching the hatch convention `lib/illustrativeStyle.ts`
+ * documents for "not measured, modelled instead". A diagonal hatch sits over
+ * the whole track (not just the filled portion) so this control never reads
+ * as a continuation of TimelineBar's solid observed track, and the thumb is
+ * a small square rather than a circle for the same reason.
+ */
+.range-slider-forecast {
+  --range-progress: 0%;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 16px;
+  margin: 0;
+  background: transparent;
+  cursor: pointer;
+}
+.range-slider-forecast:focus-visible {
+  outline: none;
+}
+.range-slider-forecast:disabled {
+  cursor: default;
+}
+.range-slider-forecast::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 999px;
+  border: 1px dashed rgba(157, 192, 255, 0.5);
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      rgba(157, 192, 255, 0.55) 0px,
+      rgba(157, 192, 255, 0.55) 2px,
+      transparent 2px,
+      transparent 5px
+    ),
+    linear-gradient(
+      to right,
+      var(--color-accent) 0%,
+      var(--color-accent) var(--range-progress),
+      rgba(255, 255, 255, 0.06) var(--range-progress),
+      rgba(255, 255, 255, 0.06) 100%
+    );
+}
+.range-slider-forecast::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  margin-top: -4px;
+  border-radius: 3px;
+  background: #9dc0ff;
+  border: 2px solid var(--color-accent);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  transition: transform 120ms ease;
+}
+.range-slider-forecast:hover::-webkit-slider-thumb,
+.range-slider-forecast:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.15);
+}
+.range-slider-forecast:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.4);
+}
+.range-slider-forecast::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  border: 1px dashed rgba(157, 192, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.06);
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(157, 192, 255, 0.55) 0px,
+    rgba(157, 192, 255, 0.55) 2px,
+    transparent 2px,
+    transparent 5px
+  );
+}
+.range-slider-forecast::-moz-range-progress {
+  height: 4px;
+  border-radius: 999px;
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--color-accent) 0px,
+    var(--color-accent) 2px,
+    rgba(157, 192, 255, 0.7) 2px,
+    rgba(157, 192, 255, 0.7) 5px
+  );
+}
+.range-slider-forecast::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: #9dc0ff;
+  border: 2px solid var(--color-accent);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+}

--- a/apps/web/src/lib/permalink.ts
+++ b/apps/web/src/lib/permalink.ts
@@ -19,6 +19,17 @@
  *     "unspecified" and the reader's own preference decides — it never means
  *     "English". Thai is the default the project decided on, and it is never
  *     inferred from the browser (docs/roadmap.md §4)
+ *   - `t` (observed history, `atIso`) and `f` (forecast scrub, `forecastAtIso`,
+ *     E12.4a) are mutually exclusive on the wire even though the app state
+ *     they mirror is two independent `useState`s: `serialisePermalink` never
+ *     writes both, and if a caller somehow passes both non-null it writes `t`
+ *     and drops `f`. `parsePermalink` applies the same rule to a hand-edited
+ *     URL that carries both keys — `t` wins, `forecastAtIso` comes back
+ *     `null` — rather than "whichever `URLSearchParams` happens to read
+ *     first", which would make the outcome depend on key order in the query
+ *     string. `t` wins because it is the older, incumbent parameter, and
+ *     because defaulting a copied link to observed history over an unverified
+ *     forecast selection is the safer of the two misreads
  */
 import type { CameraPose } from "../scene/setupScene";
 import { DEFAULT_LANG, isLang, type Lang } from "../i18n";
@@ -29,6 +40,8 @@ export interface PermalinkState {
   exaggeration: number | null;
   layers: string[] | null;
   atIso: string | null;
+  /** null = no forecast step scrubbed (E12.4a); see the `t`/`f` note above. */
+  forecastAtIso: string | null;
   /** null = the link does not pin a language; the reader's preference wins. */
   lang: Lang | null;
 }
@@ -47,6 +60,7 @@ export interface PermalinkInput {
    */
   defaultLayers: Record<string, boolean>;
   atIso: string | null;
+  forecastAtIso: string | null;
   lang: Lang;
 }
 
@@ -65,6 +79,7 @@ export function parsePermalink(search: string): PermalinkState {
   const ex = q.get("ex");
   const layers = q.get("layers");
   const t = q.get("t");
+  const f = q.get("f");
   const lang = q.get("lang");
   return {
     provinceCode: p && /^[0-9]{2}$/.test(p) ? p : null,
@@ -72,6 +87,12 @@ export function parsePermalink(search: string): PermalinkState {
     exaggeration: ex && Number.isFinite(Number(ex)) ? Number(ex) : null,
     layers: layers ? layers.split(",").filter(Boolean) : null,
     atIso: t && Number.isFinite(Date.parse(t)) ? t : null,
+    // `t` wins over `f` on a hand-edited URL that carries both — see the
+    // header comment. The check is on the `t` *key being present at all*,
+    // not on whether it parses: a URL author who wrote both is claiming
+    // observed history, however malformed that claim turns out to be, and
+    // `f` never gets to fill the gap a bad `t` leaves behind.
+    forecastAtIso: t === null && f && Number.isFinite(Date.parse(f)) ? f : null,
     lang: isLang(lang) ? lang : null,
   };
 }
@@ -93,7 +114,11 @@ export function serialisePermalink(state: PermalinkInput): string {
     ([k, v]) => v !== (state.defaultLayers[k] ?? true),
   );
   if (differsFromDefault) q.set("layers", on.join(","));
+  // `t` and `f` never both go on the wire — see the header comment. `t`
+  // (observed) wins even if the caller passed both non-null, so `f` is only
+  // ever written once `atIso` has already been ruled out.
   if (state.atIso) q.set("t", state.atIso);
+  else if (state.forecastAtIso) q.set("f", state.forecastAtIso);
   if (state.lang !== DEFAULT_LANG) q.set("lang", state.lang);
   return `?${q.toString()}`;
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -751,9 +751,10 @@ artefact exists or is needed) — but polygon distance is what this task specifi
 
 Unlike E1–E10 above, this epic does not come from the audit: it is **W7+W8** of
 `docs/roadmap-Impact Decision-Support.md`. E12.1 (contract), E12.2 (ingestion, Durable Object,
-routes) and E12.3 (the per-province forecast card) have landed; **the card is not yet on the map
-or timeline** — E12.4 is named here for order, not specified, and still needs its own task block
-in the format described in §0 before it is implemented.
+routes), E12.3 (the per-province forecast card) and E12.4a (the forecast time strip) have landed;
+**the card is on the timeline now but still not on the 3D map itself** — E12.4b is named here for
+order, not specified, and still needs its own task block in the format described in §0 before it
+is implemented.
 
 - **E12.1 — forecast contract and epistemic class** — *done*. `EpistemicClass` gains a fifth member
   `"forecast"`: a named, cited, third-party **deterministic** model (TMD NWP), deliberately not
@@ -809,7 +810,30 @@ in the format described in §0 before it is implemented.
   `WaterLevelHistoryPoint` and its bank-level reference line. `lib/time.ts` gains
   `formatWeekday()` (Bangkok-pinned short weekday name) for the daily bar labels. `forecast.note`
   states outright that the figures are a deterministic model output, not a probability.
-- **E12.4** — the forecast time strip, and the observed-versus-forecast visual language.
+- **E12.4a — forecast time strip** — *done*. `ForecastStrip.tsx` scrubs forward through TMD's
+  hourly steps (≤48), rendered next to `TimelineBar` (which scrubs backward through observed
+  history) — stacked in `App.tsx`, side-by-side at `@2xl` in `BottomBar.tsx` — and reuses
+  `useProvinceForecast` from E12.3, no new fetch. New `forecastAtIso` state in `App.tsx` is kept
+  mutually exclusive with `atIso` in two places: `handleAtIsoChange`/`handleForecastAtIsoChange`
+  clear the other `useState` on selection, and `serialisePermalink`/`parsePermalink` add a `f=`
+  query param that is never written alongside the existing `t=`, with `t` winning on a
+  hand-edited URL that carries both — keyed on the `t` param being *present*, not on whether it
+  parses, so a malformed `t` still suppresses `f`. Visually distinct from `TimelineBar` by pattern,
+  not colour (`.range-slider-forecast`'s hatched/dashed track, following the same
+  observed-vs-computed convention as `lib/illustrativeStyle.ts`), using the existing
+  `EPISTEMIC_BADGE.forecast` token. No colour banding on the hourly rain values shown — no
+  TMD-cited band exists at hourly granularity, only the 24 h band E12.3 already cites; a step
+  TMD did not send renders as an explicit "not sent", never `0` or blank. Tick labels are hours
+  counted from the first returned step, not from "now" (TMD's first step may not align with it).
+  **Selecting a forecast step has zero effect on the 3D map** — no prop from `ForecastStrip`
+  reaches `scene/**`.
+- **E12.4b — observed-versus-forecast visual language on the 3D map** — *not started, not yet
+  specified*. The remaining part of the original E12.4 task: a province-level forecast rain band
+  drawn on the terrain while scrubbing `forecastAtIso`. Deliberately deferred rather than folded
+  into E12.4a — reusing the existing exposure shader channel for it would make a forecast band
+  pixel-identical to observed exposure data on the same colour ramp, a data-honesty problem that
+  needs its own design decision before implementation. Needs its own task block in the format
+  described in §0 before it is implemented.
 
 **Scope decision.** **W9 (forecast → per-อปท. impact) is deliberately not in E12.** Turning forecast
 rainfall into an impact number needs a hydrological model, which stays deferred as Tier B/C


### PR DESCRIPTION
## Summary
- Adds `ForecastStrip.tsx`, a forward-scrubbing control for TMD's hourly NWP forecast (≤48 steps, actual returned length — never hardcoded), rendered beside the existing `TimelineBar` (which scrubs backward through observed history).
- New `forecastAtIso` state in `App.tsx`, mutually exclusive with the existing `atIso` — selecting one clears the other, both in component state and in a new `f=<iso>` permalink query param (never emitted alongside `t=`; `t` wins if a hand-edited URL carries both — documented and tested in `permalink.ts`/`usePermalink.test.ts`).
- Visually distinct from `TimelineBar` by track *pattern*, not color (hatched/dashed vs. solid — same observed-vs-computed convention as `lib/illustrativeStyle.ts`), using the existing `EPISTEMIC_BADGE.forecast` token.
- No color banding on hourly rain values — no TMD-cited band exists at hourly granularity (only the 24h band, already cited elsewhere). A step TMD didn't send renders an explicit "not sent" string, never `0` or blank.
- Fixed post-QA: a single-step batch (`n===1`) previously left the slider permanently unselectable (`min === max` on the range input never fires `onChange`) — now auto-selects the sole step. Also split a misleading reused i18n string for the "batch exists but zero hourly steps" case into its own key.

## Scope
This ships the timeline control and state only. **Selecting a forecast step has zero effect on the 3D map yet.** That part (tracked as E12.4b in `docs/roadmap.md`) is deliberately deferred: reusing the existing exposure shader channel for a forecast band would make it pixel-identical to observed exposure data on the same color ramp — a data-honesty problem that needs its own design decision before implementation, not made yet.

## Screenshots
Disabled/never-fetched state (TimelineBar + ForecastStrip side by side):
![disabled state](https://github.com/flukelaster/SIAHRA/releases/download/primg-feat-e12-4a-forecast-time-strip/crop2.png)

Active state, step selected, no color banding on rain:
![active state](https://github.com/flukelaster/SIAHRA/releases/download/primg-feat-e12-4a-forecast-time-strip/crop4.png)

## Test plan
- [x] `npx tsc -b` (apps/web) — clean
- [x] `npx oxlint src worker` (apps/web) — clean
- [x] `npm run test -w apps/web` — 184/184 passing (incl. 4 new permalink tests for the `f`/`t` collision rule)
- [x] Root `npm test` (api/web/etl) — 548 tests, all green
- [x] QA verified live via `playwright-cli`: real dev data for the never-fetched state, route-mocked data for the active/mutex/null-field paths — verdict `pass`
- [x] Post-QA fix (n=1 auto-select) independently re-verified live: confirmed `f=` now appears in the URL and the step renders, via a fresh route mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ey963gPdrFChb9TC1pq5a2