### PR TITLE
feat(web): Google-Maps touch gestures on the 3D map

### DIFF
--- a/apps/web/src/components/layout/Map3DCanvas.tsx
+++ b/apps/web/src/components/layout/Map3DCanvas.tsx
@@ -274,18 +274,37 @@ export function Map3DCanvas({
         qualityRef.current = quality;
         handles.addTicker(() => quality.tick(performance.now()));
 
-        // Click-to-inspect (select tool): a press+release with little movement.
-        let downAt: { x: number; y: number; t: number } | null = null;
+        // Click/tap-to-inspect: a press+release with little movement.
+        //
+        // เมาส์ยังเคารพเครื่องมือ (เฉพาะโหมด select) แต่ **จอสัมผัสไม่มีเครื่องมือแล้ว**
+        // — นิ้วเดียวเลื่อนแผนที่เสมอ การแตะจึงไม่กำกวมและต้องเลือกได้ทุกโหมด
+        // สองนิ้วขึ้นไปไม่ใช่การแตะเด็ดขาด ไม่งั้นการบีบที่จบตรงจุดเดิมจะถูกนับเป็นแตะ
+        let downAt: { x: number; y: number; t: number; touch: boolean } | null = null;
+        let activeTouches = 0;
         const onDown = (e: PointerEvent) => {
-          if (e.button !== 0) return;
-          downAt = { x: e.clientX, y: e.clientY, t: performance.now() };
+          const touch = e.pointerType === "touch";
+          if (touch) {
+            activeTouches += 1;
+            if (activeTouches > 1) {
+              downAt = null;
+              return;
+            }
+          } else if (e.button !== 0) {
+            return;
+          }
+          downAt = { x: e.clientX, y: e.clientY, t: performance.now(), touch };
         };
         const onUp = (e: PointerEvent) => {
-          if (!downAt || e.button !== 0) return;
+          const touch = e.pointerType === "touch";
+          if (touch) activeTouches = Math.max(0, activeTouches - 1);
+          if (!downAt || (!touch && e.button !== 0)) return;
           const moved = Math.hypot(e.clientX - downAt.x, e.clientY - downAt.y);
           const held = performance.now() - downAt.t;
+          const wasTouch = downAt.touch;
           downAt = null;
-          if (moved > 5 || held > 600 || toolRef.current !== "select") return;
+          if (!wasTouch && toolRef.current !== "select") return;
+          // นิ้วสั่นกว่าเมาส์ — การเลื่อนย่อมเกินเกณฑ์นี้อยู่แล้วโดยนิยาม
+          if (moved > (wasTouch ? 10 : 5) || held > 600) return;
           const h = sceneRef.current;
           const loaded = terrainRef.current;
           if (!h || !loaded) return;
@@ -303,12 +322,20 @@ export function Map3DCanvas({
           });
           setPick(result);
         };
+        // iOS ยิง pointercancel ใจกว้าง (ปัดขอบจอ ดึงศูนย์แจ้งเตือน) — ถ้าไม่ล้าง
+        // ตัวนับนิ้วจะค้างแล้วการแตะครั้งถัดไปถูกมองเป็นการบีบตลอดไป
+        const onCancel = () => {
+          activeTouches = 0;
+          downAt = null;
+        };
         container.addEventListener("pointerdown", onDown);
         container.addEventListener("pointerup", onUp);
+        container.addEventListener("pointercancel", onCancel);
         const origDispose = handles.dispose;
         handles.dispose = () => {
           container.removeEventListener("pointerdown", onDown);
           container.removeEventListener("pointerup", onUp);
+          container.removeEventListener("pointercancel", onCancel);
           origDispose();
         };
 
@@ -1099,7 +1126,7 @@ export function Map3DCanvas({
 
   return (
     <div className="absolute inset-0">
-      <div ref={containerRef} className="map-sky absolute inset-0" />
+      <div ref={containerRef} className="map-sky absolute inset-0 touch-none" />
       {pick ? (
         <div ref={popupDivRef} className="pointer-events-none absolute top-0 left-0 z-30 will-change-transform">
           <InfoPopup pick={pick} onClose={closePopup} />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -43,6 +43,9 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
+  /* กันการเด้ง rubber-band ของ iOS ตอนลากแผนที่ถึงขอบ (ซ้ำซ้อนกับ overflow:hidden
+     ข้างบนโดยตั้งใจ — Safari บางรุ่นยังเด้งแม้ body จะไม่เลื่อน) */
+  overscroll-behavior: none;
 }
 
 * {

--- a/apps/web/src/scene/setupScene.ts
+++ b/apps/web/src/scene/setupScene.ts
@@ -4,6 +4,7 @@ import { Sky } from "three/addons/objects/Sky.js";
 import { sunPosition } from "./sun";
 import { CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
 import { fitProjectedExtent } from "./fitProjectedExtent";
+import { attachTouchGestures } from "./touchGestures";
 import type { AoiManifest } from "@siahra/shared-types";
 
 export type MapTool = "select" | "pan";
@@ -160,16 +161,27 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
 
   const controls = new OrbitControls(camera, renderer.domElement);
   controls.enableDamping = true;
-  controls.dampingFactor = 0.08;
+  // `_panOffset` เป็นตัวสะสมแบบรั่ว: ระยะรวมถูกต้อง (อนุกรมเรขาคณิตรวมเป็น 1) แต่
+  // **ตามหลังนิ้ว** — 0.08 คือ τ ≈ 12.5 เฟรม ≈ 208 ms ที่ 60fps ซึ่งบนจอสัมผัสอ่าน
+  // ได้ว่า "หน่วง/ยืด" ทันที ส่วนเมาส์ไม่ได้ลากตัวชี้ไปด้วยจึงไม่รู้สึก
+  const coarsePointer = window.matchMedia("(pointer: coarse)").matches;
+  controls.dampingFactor = coarsePointer ? 0.2 : 0.08;
   controls.maxPolarAngle = Math.PI * 0.47;
   controls.minDistance = 300;
   controls.maxDistance = 8000;
   controls.zoomSpeed = 0.9;
   controls.rotateSpeed = 0.7;
-  controls.panSpeed = 0.9;
+  // 1:1 กับนิ้วที่ระยะ target (0.9 ทำให้แผนที่ตามช้ากว่านิ้ว 10%)
+  controls.panSpeed = 1.0;
   controls.screenSpacePanning = false;
+  // Touch เป็นแบบ Google Maps และ **ไม่ขึ้นกับ tier หรือเครื่องมือ**: นิ้วเดียวเลื่อน
+  // สองนิ้วบีบซูม + ก้มเงย (Δy) + ทิศ (Δx) ส่วนการบิดเติมใน `attachTouchGestures`
+  // การแมปเมาส์ยังตามเครื่องมือเหมือนเดิม (ดู setTool)
+  controls.touches.ONE = THREE.TOUCH.PAN;
+  controls.touches.TWO = THREE.TOUCH.DOLLY_ROTATE;
   controls.target.set(0, 0, 0);
   controls.update();
+  const detachTouch = attachTouchGestures(controls, camera, renderer.domElement);
 
   // Satellite imagery is already lit by the sun, so lighting is mostly a
   // soft sky/ground ambient with one warm key light for relief and shadows.
@@ -364,10 +376,11 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
     controls.update();
   };
 
+  // เมาส์เท่านั้น — touch ถูกตรึงไว้ที่ ONE=PAN / TWO=DOLLY_ROTATE ตอนตั้งค่า
+  // เพื่อให้จอสัมผัสทำตัวเหมือน Google Maps ไม่ว่าเครื่องมือจะเป็นอะไร
   const setTool = (tool: MapTool) => {
     controls.mouseButtons.LEFT = tool === "pan" ? THREE.MOUSE.PAN : THREE.MOUSE.ROTATE;
     controls.mouseButtons.RIGHT = tool === "pan" ? THREE.MOUSE.ROTATE : THREE.MOUSE.PAN;
-    controls.touches.ONE = tool === "pan" ? THREE.TOUCH.PAN : THREE.TOUCH.ROTATE;
   };
 
   let fly: {
@@ -617,6 +630,7 @@ export function setupScene(container: HTMLDivElement): SceneHandles {
     debugReaders.clear();
     cancelAnimationFrame(frameId);
     resizeObserver.disconnect();
+    detachTouch();
     controls.dispose();
     renderer.dispose();
     tickers.clear();

--- a/apps/web/src/scene/touchGestures.ts
+++ b/apps/web/src/scene/touchGestures.ts
@@ -1,0 +1,162 @@
+import * as THREE from "three";
+import type { OrbitControls } from "three/addons/controls/OrbitControls.js";
+
+/** ระยะที่แต่ละนิ้วต้องขยับก่อนจึงจะจำแนก gesture สองนิ้วได้ (CSS px) */
+const CLASSIFY_MIN_PX = 8;
+/** dot ของเวกเตอร์การขยับสองนิ้ว เกินค่านี้ = ไปทางเดียวกัน = ลาก (ก้มเงย/ทิศ) */
+const PARALLEL_DOT = 0.35;
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+interface Pt {
+  x: number;
+  y: number;
+}
+
+/**
+ * Two-finger twist → compass bearing, Google-Maps style.
+ *
+ * OrbitControls r185 ไม่มี gesture บิด (ทั้งไฟล์ไม่มีการหามุมระหว่างสองนิ้วเลย —
+ * state ของสองนิ้วมีแค่ "จุดกึ่งกลาง" กับ "ระยะห่าง") เราจึงเติมเอง โดยหมุน
+ * `camera.position` รอบแกนดิ่งที่ลากผ่าน `controls.target`
+ *
+ * ที่ทำแบบนี้ได้เพราะ `OrbitControls#update()` **สร้าง spherical ใหม่จากตำแหน่ง
+ * กล้องจริงทุกเฟรม** แล้วจบด้วย `lookAt(target)` — การเขียน `camera.position`
+ * ตรง ๆ จึงถูก "รับช่วง" ไม่ใช่ถูกล้างทิ้ง และเราไม่ต้องเรียก `lookAt`/`update()` เอง
+ * (มันยังยิง event `change` ให้ด้วย ลูปเรนเดอร์จึงเด้งขึ้น 60fps เองอัตโนมัติ)
+ *
+ * การจำแนก: หนึ่งรอบสองนิ้วถูกตัดสิน **ครั้งเดียว** ว่าเป็น "twist" หรือ "drag"
+ * — "twist" พัก flag สาธารณะ `controls.enableRotate` ไว้ ให้ DOLLY_ROTATE เหลือแต่
+ * การซูม แล้วเราคุมทิศเอง ส่วน "drag" ปล่อยไว้ตามเดิม ให้ DOLLY_ROTATE ให้ก้มเงย
+ * จาก Δy และทิศจาก Δx
+ *
+ * **ต้องเหนียวทั้งรอบ ไม่ใช่เรื่องรสนิยม**: `_rotateStart.copy(_rotateEnd)` อยู่ใน
+ * `_handleTouchMoveRotate` ที่เดียว ถ้า `enableRotate` กะพริบระหว่างรอบ จุดอ้างจะค้าง
+ * อยู่ที่เฟรมที่ปิด แล้ว delta ก้อนใหญ่จะถูกใส่รวดเดียวในเฟรมที่เปิดกลับ
+ *
+ * ไม่มีการอ่าน/เขียนสมาชิกที่ขึ้นต้นด้วย `_` ของ OrbitControls เลย — แตะเฉพาะ
+ * `enableRotate` ซึ่งเป็น API สาธารณะ
+ */
+export function attachTouchGestures(
+  controls: OrbitControls,
+  camera: THREE.Camera,
+  element: HTMLElement,
+): () => void {
+  const pts = new Map<number, Pt>();
+  let mode: "twist" | "drag" | null = null;
+  let rotateWasEnabled = controls.enableRotate;
+  let startA: Pt | null = null;
+  let startB: Pt | null = null;
+  let prevAngle = 0;
+
+  const twoIds = (): [number, number] => {
+    const it = pts.keys();
+    return [it.next().value as number, it.next().value as number];
+  };
+  /** y ชี้ลงใน coordinate ของหน้าจอ — มุมจึงเป็น "ตามเข็ม = เพิ่ม" */
+  const angleOf = (a: Pt, b: Pt) => Math.atan2(b.y - a.y, b.x - a.x);
+
+  const beginPair = () => {
+    const [i, j] = twoIds();
+    const a = pts.get(i);
+    const b = pts.get(j);
+    if (!a || !b) return;
+    startA = { ...a };
+    startB = { ...b };
+    prevAngle = angleOf(a, b);
+    mode = null;
+    rotateWasEnabled = controls.enableRotate;
+  };
+
+  /** คืน enableRotate เสมอ — ถ้าปล่อยค้างเป็น false มันจะไปฆ่าการหมุนด้วยเมาส์บนเดสก์ท็อป */
+  const endPair = () => {
+    if (mode === "twist") controls.enableRotate = rotateWasEnabled;
+    mode = null;
+    startA = null;
+    startB = null;
+  };
+
+  const onDown = (e: PointerEvent) => {
+    if (e.pointerType !== "touch") return;
+    pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pts.size === 2) beginPair();
+    else if (pts.size > 2) endPair();
+  };
+
+  const onMove = (e: PointerEvent) => {
+    if (e.pointerType !== "touch" || !pts.has(e.pointerId)) return;
+    pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pts.size !== 2 || !startA || !startB) return;
+
+    const [i, j] = twoIds();
+    const a = pts.get(i);
+    const b = pts.get(j);
+    if (!a || !b) return;
+
+    // จำแนกตอน move เท่านั้น ห้ามตอน down — ถ้า enableRotate เป็น false อยู่ก่อนที่
+    // onTouchStart case 2 ของ OrbitControls จะทำงาน มันจะข้ามการตั้งจุดอ้างของ rotate
+    if (mode === null) {
+      const dax = a.x - startA.x;
+      const day = a.y - startA.y;
+      const dbx = b.x - startB.x;
+      const dby = b.y - startB.y;
+      const la = Math.hypot(dax, day);
+      const lb = Math.hypot(dbx, dby);
+      if (la < CLASSIFY_MIN_PX || lb < CLASSIFY_MIN_PX) {
+        prevAngle = angleOf(a, b); // ยังไม่ตัดสิน แต่จุดอ้างต้องสด (การบีบยังทำงานปกติ)
+        return;
+      }
+      const dot = (dax * dbx + day * dby) / (la * lb);
+      mode = dot > PARALLEL_DOT ? "drag" : "twist";
+      if (mode === "twist") controls.enableRotate = false;
+      prevAngle = angleOf(a, b);
+      return;
+    }
+
+    if (mode !== "twist") return;
+
+    const now = angleOf(a, b);
+    let d = now - prevAngle;
+    if (d > Math.PI) d -= 2 * Math.PI; // คลี่รอยต่อของ atan2
+    else if (d < -Math.PI) d += 2 * Math.PI;
+    prevAngle = now;
+    if (d === 0) return;
+
+    const off = new THREE.Vector3().subVectors(camera.position, controls.target);
+    off.applyAxisAngle(UP, d);
+    camera.position.copy(controls.target).add(off);
+  };
+
+  const onUp = (e: PointerEvent) => {
+    if (!pts.delete(e.pointerId)) return;
+    if (pts.size < 2) endPair();
+  };
+
+  // ผูก move/up ที่ window ไม่ใช่ element — `setPointerCapture` ของ OrbitControls
+  // จับแค่ **นิ้วแรก** นิ้วที่สองจึงหยุดรายงานถ้าไถลออกนอกกล่อง
+  element.addEventListener("pointerdown", onDown);
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+  window.addEventListener("pointercancel", onUp);
+
+  // page pinch-zoom ของ iOS Safari: `touch-action: none` **ไม่หยุดมัน** (WebKit ไม่สนใจ
+  // touch-action สำหรับการซูมระดับหน้า) event ตระกูล gesture* ของ WebKit หยุดได้ และ
+  // ต่างจาก preventDefault บน touchmove ตรงที่ไม่ไปกดการส่ง pointer event ต่อ
+  // ซึ่งจะฆ่า OrbitControls เอง
+  const killGesture = (e: Event) => e.preventDefault();
+  element.addEventListener("gesturestart", killGesture, { passive: false });
+  element.addEventListener("gesturechange", killGesture, { passive: false });
+  element.addEventListener("gestureend", killGesture, { passive: false });
+
+  return () => {
+    endPair();
+    controls.enableRotate = rotateWasEnabled;
+    element.removeEventListener("pointerdown", onDown);
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    window.removeEventListener("pointercancel", onUp);
+    element.removeEventListener("gesturestart", killGesture);
+    element.removeEventListener("gesturechange", killGesture);
+    element.removeEventListener("gestureend", killGesture);
+  };
+}


### PR DESCRIPTION
## Why

On a phone, one finger **orbited** the map. Panning required first tapping the "hand" tool in the right-edge column. No map behaves like that, and the toggle is invisible to anyone who does not go looking for it.

## What

Touch is now Google-Maps-shaped and independent of the tool:

| gesture | before | after |
|---|---|---|
| one finger drag | orbit | **pan** (ground plane) |
| two finger pinch | dolly + pan | **dolly** |
| two finger drag ↕ | pan | **tilt** |
| two finger twist | — | **bearing** |
| tap | inspect (select tool only) | inspect (any tool on touch) |

`touches.ONE = PAN` / `touches.TWO = DOLLY_ROTATE` are set once at scene setup. `DOLLY_ROTATE` already gives pinch-dolly and two-finger-drag rotate on the same move event, and its tilt sign matches Google Maps as-is (`_rotateUp` does `phi -= angle`). `setTool` now maps the **mouse only** — the orbit/pan buttons on tablet and up are unchanged.

### The twist gesture

OrbitControls r185 has none — there is no angle computed between two pointers anywhere in the file; the only two-pointer state is the midpoint and the scalar separation. `scene/touchGestures.ts` adds it by orbiting `camera.position` about the vertical axis through `controls.target`. This works because `update()` rebuilds its spherical from the live camera position every frame and ends with `lookAt(target)`, so the mutation is adopted rather than clobbered.

A two-finger session is classified **once** as twist or drag. Twist parks the public `enableRotate` flag so the horizontal midpoint drift cannot double up the bearing change. The classification is sticky by necessity, not taste: `_rotateStart.copy(_rotateEnd)` lives in one place, so a flag that flickers mid-gesture leaves a stale reference point and applies one large jump in a single frame. The flag is restored on pointer count < 2, on `pointercancel`, and in the disposer — leaking it would silently kill mouse rotate on desktop.

Only public API is touched: `enableRotate`, `enableZoom`, `touches`, `mouseButtons`. No `_`-prefixed member is read or written.

### Feel

`panSpeed` 0.9 → 1.0, and `dampingFactor` 0.2 on coarse pointers (0.08 elsewhere). At 0.08 the pan accumulator trails the finger by ~208 ms at 60 fps, which reads as lag when your finger is on the thing that is lagging. Desktop is bit-identical.

### iOS

Page pinch-zoom is suppressed via WebKit's proprietary `gesturestart`/`gesturechange`/`gestureend`. `touch-action` does not cover page-level scaling, and `preventDefault` on `touchmove` would suppress the pointer events OrbitControls needs. `viewport-fit=cover` is deliberately **not** added: nothing reads `env(safe-area-inset-*)`, so it would push the layout under the notch and slide the right-edge tool column beneath the rounded corner.

## Verification

`tsc -b`, `oxlint src worker` and the full test suite (api 425 / web 224 / etl 78) are green, and desktop was confirmed unchanged at 800×700 and 1440×900.

**Not yet verified on hardware.** Headless Chromium cannot synthesise a two-finger twist, so these remain open until someone opens the branch on a real phone:

- twist **direction** — if the map turns against the fingers, negate `d` in `onMove` (one character)
- whether the `gesture*` `preventDefault` actually stops iOS Safari page pinch-zoom
- how `dampingFactor: 0.2` feels (tune 0.15–0.25)

Green CI here means the code compiles and the layout half is sound; it does not mean the gestures are verified.

## Note

No visible change, hence the `no-screenshot` label.
