### PR TITLE
fix(web): phone sheet overflow, floating scale capsule, crammed forecast strip

### DIFF
--- a/apps/web/src/components/layout/MobileSheet.tsx
+++ b/apps/web/src/components/layout/MobileSheet.tsx
@@ -141,20 +141,35 @@ export function MobileSheet({
       {open ? (
         <div
           {...bodyHandlers}
-          className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2 pb-3"
-          style={{ touchAction: "pan-y" }}
+          className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2"
+          // pb ชดเชยส่วนของแผ่นที่ถูกเลื่อนตกขอบจอ (ดู useSheetDrag) — ที่ full ค่านี้เป็น 0
+          style={{ touchAction: "pan-y", paddingBottom: "calc(0.75rem + var(--sheet-tx, 0px))" }}
         >
-          <StatPills
-            summary={ctx.observations.data?.summary ?? null}
-            loading={ctx.observations.loading}
-            compact
-          />
-          <ForecastStrip
-            state={ctx.forecast}
-            forecastAtIso={forecastAtIso}
-            onChange={onForecastAtIsoChange}
-            variant="dense"
-          />
+          {/* ตัวเลขสรุป + มาตราส่วนแนวดิ่งอยู่แถวเดียวกัน: ทั้งคู่เป็นของทั้งแผนที่
+              ไม่ใช่ของแผงใดแผงหนึ่ง จึงต้องอยู่เหนือแถบแท็บ ไม่ใช่ท้ายสุดใต้แผง
+              ซึ่งต้องเลื่อนผ่านรายการยาว ๆ กว่าจะเจอ */}
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <StatPills
+              summary={ctx.observations.data?.summary ?? null}
+              loading={ctx.observations.loading}
+              compact
+            />
+            <div className="ml-auto">
+              <ExaggerationControl value={exaggeration} onChange={onExaggerationChange} compact />
+            </div>
+          </div>
+          {/* แบบ `dense` ใช้ไม่ได้ที่ความกว้างนี้: ป้าย "พยากรณ์จากแบบจำลอง TMD"
+              กับค่าฝนย่อไม่ได้ (ป้ายบอกว่านี่คือแบบจำลอง ไม่ใช่ค่าที่วัด — ตัดทิ้ง
+              ไม่ได้) รวมกับปุ่มล้างแล้วกินไปแล้ว ~320 จาก 372px สไลเดอร์เลยเหลือ
+              ไม่ถึงนิ้ว แบบเต็มวางสไลเดอร์คนละบรรทัดกับป้าย และ body นี้เลื่อนได้
+              อยู่แล้ว ความสูงจึงถูกกว่าความกว้าง */}
+          <div className="shrink-0">
+            <ForecastStrip
+              state={ctx.forecast}
+              forecastAtIso={forecastAtIso}
+              onChange={onForecastAtIsoChange}
+            />
+          </div>
 
           <div className="flex shrink-0 items-center gap-1 overflow-x-auto">
             {PANELS.map((p) => {
@@ -180,11 +195,10 @@ export function MobileSheet({
             })}
           </div>
 
-          <div className="min-h-0">{current.render(ctx)}</div>
-
-          <div className="shrink-0 self-start pt-1">
-            <ExaggerationControl value={exaggeration} onChange={onExaggerationChange} compact />
-          </div>
+          {/* `shrink-0` ไม่ใช่ `min-h-0`: ในคอลัมน์ flex ที่เลื่อนได้ กล่องที่ยอมหด
+              จะถูกบีบให้พอดีที่ว่างแล้วเนื้อหาข้างในล้นออกมาโดยไม่มีอะไรคลิป —
+              ของที่อยู่ถัดไปจึงถูกวาดทับรายการในแผง (เห็นบน iPhone จริง) */}
+          <div className="shrink-0">{current.render(ctx)}</div>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/hooks/useSheetDrag.ts
+++ b/apps/web/src/hooks/useSheetDrag.ts
@@ -70,6 +70,12 @@ export function useSheetDrag({
       tx.current = Math.max(0, elH - visibleFor(s));
       el.style.transition = animate ? REST_TRANSITION : "none";
       el.style.transform = `translate3d(0, ${tx.current}px, 0)`;
+      // แผ่นสูงคงที่แล้วถูกเลื่อนลง ก้นของมันจึงอยู่ **ต่ำกว่าขอบจอ** เท่ากับระยะเลื่อน
+      // ที่ทุกสแนปยกเว้น full — ส่วนท้ายของกล่องที่เลื่อนได้ก็เลยตกไปอยู่นอกจอ และ
+      // เนื้อหาแถวสุดท้ายเลื่อนขึ้นมาดูไม่ได้ ชดเชยด้วย padding ล่างเท่าระยะเลื่อน
+      // (padding นับรวมใน scroll extent) — เขียนเฉพาะตอนเข้าที่ ไม่ใช่ทุกเฟรมของการลาก
+      // เพราะการเปลี่ยน padding คือ layout ส่วน transform ไม่ใช่
+      el.style.setProperty("--sheet-tx", `${tx.current}px`);
     },
     [sheetRef, visibleFor],
   );


### PR DESCRIPTION
Three layout defects reported from a real iPhone that the headless pass in #70 did not catch.

## 1. The last rows of the sheet body were unreachable

The sheet is a fixed `92dvh` box translated down, so at every snap except `full` its **bottom edge sits below the viewport** by the translate distance — 312 px at half on an 844 px screen. The scroll container ended down there with it, so scrolling to the end left the final content off-screen. On the layers panel that meant the legend and the `/api/v1/health` status footer could not be read at all.

The body now carries a bottom padding equal to the translate, written as a CSS custom property in `useSheetDrag`'s rest path **only**. Padding counts toward the scroll extent, and writing it on settle rather than per frame keeps the drag itself transform-only — changing padding is layout, transform is not.

## 2. The vertical-scale capsule floated over the panel list

`<div className="min-h-0">{current.render(ctx)}</div>` — inside a flex column a box that may shrink gets compressed to whatever space is left, and with no `overflow` set its content spills out unclipped. Everything after it was then painted across the rows. It is `shrink-0` now.

The capsule also moved up beside the stat pills. Both are map-wide controls rather than anything belonging to a panel, and at the end of the body it sat behind a long scroll.

## 3. The dense forecast strip is unusable at this width once TMD data arrives

The clear button, the "forecast model" badge and the rain readout cannot shrink — **the badge is what states these numbers are modelled rather than measured**, so truncating it is not an option — and together they take ~320 px of 372, leaving the slider under a finger-width.

Phone now uses the **full** variant, which puts the slider on its own row. The body scrolls, so height is cheaper than width there.

**Why headless missed it:** the local API had never fetched TMD, so the strip rendered its never-fetched empty state, which is a single line. Reproducing it needed `GET /__scheduled?cron=*+*+*+*+*` to populate the DO first.

## Verification

390×844 and 360×640 with a populated forecast:

- last row of the layers panel lands at **y=831 of 844** at both half and full (was ~1140, i.e. off-screen)
- `--sheet-tx` is ~0 at full, so there is no dead gap at the tallest snap
- peek measures **200 px** against the 240 px ceiling
- `tsc -b`, `oxlint src worker` and the full suite green (api 425 / web 224 / etl 78)

<table><tr>
<td width="50%"><img src="https://github.com/flukelaster/SIAHRA/releases/download/primg-fix-mobile-sheet-overflow/fix-half2.png" width="330" alt="Phone 390x844 at the half snap: stat pills and the vertical-scale capsule share a row above the full-variant forecast strip, whose slider spans its own line" /></td>
<td width="50%"><img src="https://github.com/flukelaster/SIAHRA/releases/download/primg-fix-mobile-sheet-overflow/fix-scrolled2.png" width="330" alt="Same sheet scrolled to the end: the legend and the data-status footer are fully visible instead of ending below the viewport" /></td>
</tr></table>

<img src="https://github.com/flukelaster/SIAHRA/releases/download/primg-fix-mobile-sheet-overflow/fix-360-half.png" width="330" alt="Smallest supported viewport 360x640 at the half snap, with no overlap between the peek rows, the stat pills, the scale capsule and the forecast strip" />
